### PR TITLE
Keyerror fix

### DIFF
--- a/server/effect_update_server.py
+++ b/server/effect_update_server.py
@@ -137,16 +137,12 @@ def effect_update_server(input, output, session, shared):
 
     @reactive.effect
     def update_select_label_nn():
-        adata = ad.AnnData(obs=shared['obs_data'].get())
+        with reactive.isolate():
+            adata = ad.AnnData(obs=shared['obs_data'].get())
         if input.nn_anno():
             selected_anno = input.nn_anno()
-            # Check if the column exists
-            if selected_anno in adata.obs.columns: 
-                labels = adata.obs[selected_anno].unique().tolist()
-                ui.update_select("nn_anno_label", choices=labels)
-            else:
-                print(f"Warning: Annotation '{selected_anno}' not found in the dataset.")
-                ui.update_select("nn_anno_label", choices=[])
+            labels = adata.obs[selected_anno].unique().tolist()
+            ui.update_select("nn_anno_label", choices=labels)
 
     @reactive.effect
     def update_select_df_nn():

--- a/server/effect_update_server.py
+++ b/server/effect_update_server.py
@@ -140,8 +140,13 @@ def effect_update_server(input, output, session, shared):
         adata = ad.AnnData(obs=shared['obs_data'].get())
         if input.nn_anno():
             selected_anno = input.nn_anno()
-            labels = adata.obs[selected_anno].unique().tolist()
-            ui.update_select("nn_anno_label", choices=labels)
+            # Check if the column exists
+            if selected_anno in adata.obs.columns: 
+                labels = adata.obs[selected_anno].unique().tolist()
+                ui.update_select("nn_anno_label", choices=labels)
+            else:
+                print(f"Warning: Annotation '{selected_anno}' not found in the dataset.")
+                ui.update_select("nn_anno_label", choices=[])
 
     @reactive.effect
     def update_select_df_nn():


### PR DESCRIPTION
This pull request fixes #46. When a new dataset (healthy_lung_data) is uploaded after another dataset (preloaded_data), the reactive effect `update_select_label_nn` was called before `update_select_input_anno`, causing the app to try and access an annotation from the preloaded_data that isn't in healthy_lung_data, causing a key error.

This PR adds a `reactive.isolate()` block to ensure that the `update_select_input_anno` effect occurs first, updating the stored annotation choices before the `update_select_label_nn` effect occurs