### PR TITLE
Integration of Datashader Library into Automatically Scaling Scatter Plot Heatmaps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/environment.yml
+++ b/environment.yml
@@ -18,9 +18,9 @@ dependencies:
   - squidpy=1.2.2
   - scikit-image=0.19.3
   - scipy=1.10.1
-  - colorcet
   - pip
   - pip:
+      - colorcet
       - git+https://github.com/holoviz/datashader.git
       - ipykernel==6.29.5
       - ipython==8.18.0

--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ channels:
   - leej3
   - https://fnlcr-dmap.github.io/scimap/
 dependencies:
-  - python=3.10
+  - python=3.9.13
   - numpy=1.26.4
   - pandas=1.5.3
   - anndata=0.10.9

--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ channels:
   - leej3
   - https://fnlcr-dmap.github.io/scimap/
 dependencies:
-  - python=3.9.13
+  - python=3.10
   - numpy=1.26.4
   - pandas=1.5.3
   - anndata=0.10.9
@@ -18,8 +18,10 @@ dependencies:
   - squidpy=1.2.2
   - scikit-image=0.19.3
   - scipy=1.10.1
+  - colorcet
   - pip
   - pip:
+      - git+https://github.com/holoviz/datashader.git
       - ipykernel==6.29.5
       - ipython==8.18.0
       - ipython-genutils==0.2.0

--- a/ui/scatterplot_ui.py
+++ b/ui/scatterplot_ui.py
@@ -32,6 +32,11 @@ def scatterplot_ui():
                             "Color by Feature",
                             value=False
                         ),
+                        ui.input_checkbox(
+                            "scatter_heatmap_mode",
+                            "Show as Heatmap",
+                            value=False
+                        ),
                         ui.div(id="main-scatter_dropdown"),
                         ui.input_action_button(
                             "go_scatter",

--- a/utils/datashader_utils.py
+++ b/utils/datashader_utils.py
@@ -1,0 +1,16 @@
+import pandas as pd
+import datashader as ds
+import datashader.transfer_functions as tf
+from colorcet import fire
+
+def scatter_heatmap(x, y, color=None, width=800, height=600):
+    df = pd.DataFrame({'x': x, 'y': y})
+    cvs = ds.Canvas(plot_width=width, plot_height=height)
+    if color is not None:
+        df['color'] = color
+        agg = cvs.points(df, 'x', 'y', ds.mean('color'))
+        img = tf.shade(agg, cmap=fire, how='eq_hist')
+    else:
+        agg = cvs.points(df, 'x', 'y', ds.count())
+        img = tf.shade(agg, cmap=fire)
+    return img.to_pil()


### PR DESCRIPTION
Description:
The goal of this is to implement automatic heatmap scaling through the datashader app. This allows better visualization of the data. Before, the data could be compressed tightly, with limited readability. Now, with automatic scaling and pin color additions, this issue should be resolved.

Requirements:
OS: Ubuntu via WSL on Windows 11
Python Version: 3.9.13 (Miniconda)
Conda Environment: spacy_viz_py3913_wsl
Dataset Used: Custom .h5ad file

Solution:
The integration is as follows. A button would display the heatmap using the datashader library. In order to implement this, a utility function renders the heatmap using the library. The utility function creates a high-resolution heatmap using Datashader, visualizing point density or average color values. For the server logic, I created a mode for the heatmap with the datashader library and color enabler for pin colors. The color enabler toggle dynamically adds or removes a dropdown menu for selecting a feature to color scatterplots or heatmaps. When active, it basically extracts and passes color values from AnnData to either Datashader or spac.visualization for enhanced visual rendering. If the color toggle is off but the heatmap toggle is on, it removes the UI color out. The addition of colorcet and datashader library is included a specific commit-based package as a dependency in environment.yml.

