### PR TITLE
Fix 'Hash Sum Mismatch' bug on mac

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,11 @@ FROM python:3.9.19-slim-bookworm
 # Set working directory
 WORKDIR /app
 
+# Fix 'Hash Sum Mismatch' bug for mac device
+RUN echo "Acquire::http::Pipeline-Depth 0;" > /etc/apt/apt.conf.d/99custom && \
+    echo "Acquire::http::No-Cache true;" >> /etc/apt/apt.conf.d/99custom && \
+    echo "Acquire::BrokenProxy    true;" >> /etc/apt/apt.conf.d/99custom
+
 # Install system dependencies needed for scientific packages
 RUN apt-get update && apt-get install -y \
     gcc \


### PR DESCRIPTION
## Description

This Pull Request suggests a possible solution to the **'Hash Sum Mismatch' bug** that happens on mac when building a docker container for the shiny app with the `Dockerfile` in the "main" branch. Please refer to issue #63 for more details of this bug including an example of the error message.

## Related Issue

Fixes #63
Also mentioned here https://github.com/FNLCR-DMAP/SPAC_Shiny/pull/59#issuecomment-3434713808 and here https://github.com/FNLCR-DMAP/SPAC_Shiny/pull/59#issuecomment-3461750762

## Changes

It added the following additional layer before "RUN apt-get update..." in the `Dockerfile`:

```
RUN echo "Acquire::http::Pipeline-Depth 0;" > /etc/apt/apt.conf.d/99custom && \
    echo "Acquire::http::No-Cache true;" >> /etc/apt/apt.conf.d/99custom && \
    echo "Acquire::BrokenProxy    true;" >> /etc/apt/apt.conf.d/99custom
```

This method comes from the discussions below. It seems that this 'Hash Sum Mismatch' bug is a widely appearing bug in docker on mac and has not been solved yet in any available releases (or maybe they do).

1. https://stackoverflow.com/questions/67732260/how-to-fix-hash-sum-mismatch-in-docker-on-mac
2. https://forums.docker.com/t/hash-sum-mismatch-writing-more-data-as-expected/45940/3
3. https://github.com/docker/for-mac/issues/7025

## Testing
This works on my end, both for 3.9.13 image and 3.9.19-slim-bookworm image.

**Local Settings**

- **Device**: MacBook Air M1 2020 (Apple Silicon, arm64), 16 GB RAM
- **Environment**: Terminal in VS Code. Base conda environment activated. Docker installed. Under the "main" branch in "FNLCR-DMAP/SPAC_Shiny" repo.
- **Network**: Without proxies (no VPNs). This bug appears under both Purdue campus' network and my home's network.
- **Docker image:** This bug appears both for the previous Python 3.9.13 image and the current Python 3.9.19-slim-bookworm image. The above solution fixes both cases.