### PR TITLE
Core refactor (HTML download, code cleanup, plot caching)

### DIFF
--- a/app.py
+++ b/app.py
@@ -116,6 +116,7 @@ def server(input, output, session):
 
     shared = {
         "preloaded_data": preloaded_data,  # Preloaded data for initial load
+        "preloaded_file_path": file_path,  # Path to preloaded file for filename extraction
         "data_loaded": data_loaded,  # Reactive to track if data is loaded
         "adata_main": adata_main,  # Main anndata object
     }
@@ -124,6 +125,11 @@ def server(input, output, session):
     # and add them to the shared dictionary
     for key in data_keys:
         shared[key] = reactive.Value(None)
+    
+    # Add reactive value for input filename
+    shared['input_filename'] = reactive.Value(None)
+    shared['boxplot_fig'] = reactive.Value(None)
+    shared['sankey_fig'] = reactive.Value(None)
 
     # Individual server components
     getting_started_server(input, output, session, shared)

--- a/server/anno_vs_anno_server.py
+++ b/server/anno_vs_anno_server.py
@@ -16,14 +16,14 @@ def anno_vs_anno_server(input, output, session, shared):
             layers=shared['layers_data'].get(), 
             dtype=shared['X_data'].get().dtype
         )
-        if adata is not None:
-            fig = spac.visualization.sankey_plot(
-                adata, 
-                source_annotation=input.sk1_anno1(), 
-                target_annotation=input.sk1_anno2()
-            )
-            return fig
-        return None
+        if adata is None:
+            return None
+        fig = spac.visualization.sankey_plot(
+            adata,
+            source_annotation=input.sk1_anno1(),
+            target_annotation=input.sk1_anno2()
+        )
+        return fig
 
     @output
     @render_widget
@@ -33,28 +33,30 @@ def anno_vs_anno_server(input, output, session, shared):
             X=shared['X_data'].get(), 
             obs=pd.DataFrame(shared['obs_data'].get())
         )
-        if adata is not None:
-            result = spac.visualization.relational_heatmap(
-                adata, 
-                source_annotation=input.rhm_anno1(), 
-                target_annotation=input.rhm_anno2()
-            )
-            shared['df_relational'].set(result['data'])
-            return result['figure']
-        return None
+        if adata is None:
+            return None
+        result = spac.visualization.relational_heatmap(
+            adata,
+            source_annotation=input.rhm_anno1(),
+            target_annotation=input.rhm_anno2()
+        )
+        shared['df_relational'].set(result['data'])
+        return result['figure']
+
 
     @render.download(filename="relational_data.csv")
     def download_df_1():
         df = shared['df_relational'].get()
-        if df is not None:
-            csv_string = df.to_csv(index=False)
-            csv_bytes = csv_string.encode("utf-8")
-            return csv_bytes, "text/csv"
-        return None
+        if df is None:
+            return None
+        csv_string = df.to_csv(index=False)
+        csv_bytes = csv_string.encode("utf-8")
+        return csv_bytes, "text/csv"
+
 
     @render.ui
     @reactive.event(input.go_rhm1, ignore_none=True)
     def download_button_ui_1():
-        if shared['df_relational'].get() is not None:
+        if shared['df_relational'].get() is None:
             return ui.download_button("download_df_1", "Download Data", class_="btn-warning")
         return None

--- a/server/anno_vs_anno_server.py
+++ b/server/anno_vs_anno_server.py
@@ -11,9 +11,9 @@ def anno_vs_anno_server(input, output, session, shared):
     @reactive.event(input.go_sk1, ignore_none=True)
     def spac_Sankey():
         adata = ad.AnnData(
-            X=shared['X_data'].get(), 
-            obs=pd.DataFrame(shared['obs_data'].get()), 
-            layers=shared['layers_data'].get(), 
+            X=shared['X_data'].get(),
+            obs=pd.DataFrame(shared['obs_data'].get()),
+            layers=shared['layers_data'].get(),
             dtype=shared['X_data'].get().dtype
         )
         if adata is None:
@@ -30,7 +30,7 @@ def anno_vs_anno_server(input, output, session, shared):
     @reactive.event(input.go_rhm1, ignore_none=True)
     def spac_Relational():
         adata = ad.AnnData(
-            X=shared['X_data'].get(), 
+            X=shared['X_data'].get(),
             obs=pd.DataFrame(shared['obs_data'].get())
         )
         if adata is None:

--- a/server/annotations_server.py
+++ b/server/annotations_server.py
@@ -59,23 +59,24 @@ def annotations_server(input, output, session, shared):
     @render.ui
     @reactive.event(input.go_h2, ignore_none=True)
     def download_histogram_button_ui():
-        if shared['df_histogram2'].get() is not None:
-            return ui.download_button(
-                "download_histogram2_df", 
-                "Download Data", 
-                class_="btn-warning"
-            )
-        return None
+        if shared['df_histogram2'].get() is None:
+            return None
+        return ui.download_button(
+            "download_histogram2_df",
+            "Download Data",
+            class_="btn-warning"
+        )
+
 
 
     @render.download(filename="annotation_histogram_data.csv")
     def download_histogram2_df():
         df = shared['df_histogram2'].get()
-        if df is not None:
-            csv_string = df.to_csv(index=False)
-            csv_bytes = csv_string.encode("utf-8")
-            return csv_bytes, "text/csv"
-        return None
+        if df is None:
+            return None
+        csv_string = df.to_csv(index=False)
+        csv_bytes = csv_string.encode("utf-8")
+        return csv_bytes, "text/csv"
 
     histogram2_ui_initialized = reactive.Value(False)
 

--- a/server/annotations_server.py
+++ b/server/annotations_server.py
@@ -17,24 +17,24 @@ def annotations_server(input, output, session, shared):
                 adata,
                 annotation=input.h2_anno()
             ).values()
-            shared['df_histogram2'].set(df) 
+            shared['df_histogram2'].set(df)
             ax.tick_params(axis='x', rotation=input.anno_slider(), labelsize=10)
             return fig
 
-        # 2) If "Group By" is CHECKED, we must always supply a 
+        # 2) If "Group By" is CHECKED, we must always supply a
         #    valid multiple parameter
         else:
-            # If user also checked "Plot Together", use their selected 
+            # If user also checked "Plot Together", use their selected
             # stack type
             if input.h2_together_check():
                 # e.g. 'stack', 'dodge', etc.
-                multiple_param = input.h2_together_drop()  
+                multiple_param = input.h2_together_drop()
 
                 together_flag = True
             else:
                 # If grouping by but not "plot together", pick a default layout
                 # or 'dodge' or any valid string
-                multiple_param = "layer"  
+                multiple_param = "layer"
                 together_flag = False
 
             fig, ax, df = spac.visualization.histogram(
@@ -44,12 +44,12 @@ def annotations_server(input, output, session, shared):
                 together=together_flag,
                 multiple=multiple_param
             ).values()
-            shared['df_histogram2'].set(df) 
+            shared['df_histogram2'].set(df)
             axes = ax if isinstance(ax, (list, np.ndarray)) else [ax]
             for ax in axes:
                 ax.tick_params(
-                    axis='x', 
-                    rotation=input.anno_slider(), 
+                    axis='x',
+                    rotation=input.anno_slider(),
                     labelsize=10
                 )
             return fig
@@ -87,8 +87,8 @@ def annotations_server(input, output, session, shared):
 
         if btn and not ui_initialized:
             dropdown = ui.input_select(
-                "h2_anno_1", 
-                "Select an Annotation", 
+                "h2_anno_1",
+                "Select an Annotation",
                 choices=shared['obs_names'].get()
             )
             ui.insert_ui(
@@ -98,8 +98,8 @@ def annotations_server(input, output, session, shared):
             )
 
             together_check = ui.input_checkbox(
-                "h2_together_check", 
-                "Plot Together", 
+                "h2_together_check",
+                "Plot Together",
                 value=True
             )
             ui.insert_ui(
@@ -121,18 +121,18 @@ def annotations_server(input, output, session, shared):
     def update_stack_type_dropdown():
         if input.h2_together_check():
             dropdown_together = ui.input_select(
-                "h2_together_drop", 
-                "Select Stack Type", 
-                choices=['stack', 'layer', 'dodge', 'fill'], 
+                "h2_together_drop",
+                "Select Stack Type",
+                choices=['stack', 'layer', 'dodge', 'fill'],
                 selected='stack'
             )
             ui.insert_ui(
                 ui.div({
-                    "id": "inserted-dropdown_together-1"}, 
+                    "id": "inserted-dropdown_together-1"},
                     dropdown_together
                 ),
                 selector="#main-h2_together_drop",
                 where="beforeEnd"
-            )      
+            )
         else:
             ui.remove_ui("#inserted-dropdown_together-1")

--- a/server/boxplot_server.py
+++ b/server/boxplot_server.py
@@ -43,49 +43,49 @@ def boxplot_server(input, output, session, shared):
             )
 
             # Proceed only if adata is valid
-            if adata is not None and adata.var is not None:
+            if adata is None and adata.var is None:
+                return None
 
-                fig, df = spac.visualization.boxplot_interactive(
-                    adata, 
-                    annotation=on_anno_check(), 
-                    layer=on_layer_check(), 
-                    features=list(input.bp_features()),
-                    showfliers=on_outlier_check(),
-                    log_scale=input.bp_log_scale(),
-                    orient=on_orient_check(),
-                    figure_height=3, 
-                    figure_width=4.8, 
-                    figure_type="interactive"
-                ).values()
+            fig, df = spac.visualization.boxplot_interactive(
+                adata,
+                annotation=on_anno_check(),
+                layer=on_layer_check(),
+                features=list(input.bp_features()),
+                showfliers=on_outlier_check(),
+                log_scale=input.bp_log_scale(),
+                orient=on_orient_check(),
+                figure_height=3,
+                figure_width=4.8,
+                figure_type="interactive"
+            ).values()
 
-                # Return the interactive Plotly figure object
-                shared['df_boxplot'].set(df)
-                print(type(fig))
-                return fig
+            # Return the interactive Plotly figure object
+            shared['df_boxplot'].set(df)
+            print(type(fig))
+            return fig
 
-        return None
 
 
     @render.download(filename="boxplot_data.csv")
     def download_boxplot():
         df = shared['df_boxplot'].get()
-        if df is not None:
-            csv_string = df.to_csv(index=False)
-            csv_bytes = csv_string.encode("utf-8")
-            return csv_bytes, "text/csv"
-        return None
+        if df is None:
+            return None
+        csv_string = df.to_csv(index=False)
+        csv_bytes = csv_string.encode("utf-8")
+        return csv_bytes, "text/csv"
 
 
     @render.ui
     @reactive.event(input.go_bp, ignore_none=True)
     def download_button_ui1():
-        if shared['df_boxplot'].get() is not None:
-            return ui.download_button(
-                "download_boxplot", 
-                "Download Data", 
-                class_="btn-warning"
-            )
-        return None
+        if shared['df_boxplot'].get() is None:
+            return None
+        return ui.download_button(
+            "download_boxplot",
+            "Download Data",
+            class_="btn-warning"
+        )
 
 
     @output
@@ -112,22 +112,22 @@ def boxplot_server(input, output, session, shared):
             )
 
             # Proceed only if adata is valid
-            if adata is not None and adata.var is not None:
+            if adata is None and adata.var is None:
+                return None
                 
-                fig, df = spac.visualization.boxplot_interactive(
-                    adata, 
-                    annotation=on_anno_check(), 
-                    layer=on_layer_check(), 
-                    features=list(input.bp_features()),
-                    showfliers=on_outlier_check(),
-                    log_scale=input.bp_log_scale(),
-                    orient=on_orient_check(),
-                    figure_height=3, 
-                    figure_width=4.8, 
-                    figure_type="static"
-                ).values()
+            fig, df = spac.visualization.boxplot_interactive(
+                adata,
+                annotation=on_anno_check(),
+                layer=on_layer_check(),
+                features=list(input.bp_features()),
+                showfliers=on_outlier_check(),
+                log_scale=input.bp_log_scale(),
+                orient=on_orient_check(),
+                figure_height=3,
+                figure_width=4.8,
+                figure_type="static"
+            ).values()
 
-                return fig
+            return fig
 
-        return None
 

--- a/server/boxplot_server.py
+++ b/server/boxplot_server.py
@@ -6,7 +6,7 @@ import spac.visualization
 
 
 def boxplot_server(input, output, session, shared):
-   # Helper functions for reusability
+# Helper functions for reusability
     def on_outlier_check():
         selected_choice = input.bp_outlier_check()
         return None if selected_choice == "none" else selected_choice
@@ -32,13 +32,12 @@ def boxplot_server(input, output, session, shared):
 
         if not input.bp_output_type():
             return None
-        else: 
-
+        else:
             adata = ad.AnnData(
-                X=shared['X_data'].get(), 
-                obs=pd.DataFrame(shared['obs_data'].get()), 
-                var=pd.DataFrame(shared['var_data'].get()), 
-                layers=shared['layers_data'].get(), 
+                X=shared['X_data'].get(),
+                obs=pd.DataFrame(shared['obs_data'].get()),
+                var=pd.DataFrame(shared['var_data'].get()),
+                layers=shared['layers_data'].get(),
                 dtype=shared['X_data'].get().dtype
             )
 
@@ -96,25 +95,24 @@ def boxplot_server(input, output, session, shared):
         This function produces a static (Plotly) boxplot image.
         """
 
-         # Only run this function if both conditions are met
+        # Only run this function if both conditions are met
 
         if input.bp_output_type():
             return None
 
-        else: 
-
+        else:
             adata = ad.AnnData(
-                X=shared['X_data'].get(), 
-                obs=pd.DataFrame(shared['obs_data'].get()), 
-                var=pd.DataFrame(shared['var_data'].get()), 
-                layers=shared['layers_data'].get(), 
+                X=shared['X_data'].get(),
+                obs=pd.DataFrame(shared['obs_data'].get()),
+                var=pd.DataFrame(shared['var_data'].get()),
+                layers=shared['layers_data'].get(),
                 dtype=shared['X_data'].get().dtype
             )
 
             # Proceed only if adata is valid
             if adata is None and adata.var is None:
                 return None
-                
+
             fig, df = spac.visualization.boxplot_interactive(
                 adata,
                 annotation=on_anno_check(),

--- a/server/data_input_server.py
+++ b/server/data_input_server.py
@@ -1,6 +1,300 @@
+"""
+Data input server module for SPAC Shiny application.
+
+This module handles file uploads and data loading with caching support
+for improved performance across all analysis modules.
+"""
+
 from shiny import render, reactive
+from utils.data_processing import cached_load_data
 import pickle
 import anndata as ad
+
+
+def data_input_server(input, output, session, shared):
+    """
+    Server logic for data input and loading.
+    
+    Parameters
+    ----------
+    input : shiny.session.Inputs
+        Shiny input object
+    output : shiny.session.Outputs
+        Shiny output object
+    session : shiny.session.Session
+        Shiny session object
+    shared : dict
+        Shared reactive values across modules
+    """
+    
+    @reactive.Effect
+    def adata_filter():
+        """
+        Load and cache AnnData from file upload or preloaded data.
+        
+        Uses cached loading to avoid repeated file I/O, providing
+        performance benefits across all analysis modules.
+        """
+        print("Calling Data")
+        file_info = input.input_file()
+        
+        if not file_info:
+            # Only set preloaded data if it exists
+            if shared['preloaded_data'] is not None:
+                shared['adata_main'].set(shared['preloaded_data'])
+                shared['data_loaded'].set(True)
+            else:
+                shared['data_loaded'].set(False)
+        else:
+            file_path = file_info[0]['datapath']
+            # Use cached loader for performance - data shared across all modules
+            shared['adata_main'].set(cached_load_data(file_path))
+            shared['data_loaded'].set(True)
+
+    @reactive.Effect
+    def update_parts():
+        """
+        Extract and update shared data components from loaded AnnData.
+        
+        Parses the main AnnData object and populates shared reactive
+        values for use across all modules (spatial, violin, etc.).
+        """
+        print("Updating Parts")
+        adata = shared['adata_main'].get()
+        
+        if adata is not None:
+            # Extract all AnnData components
+            if hasattr(adata, 'X'):
+                shared['X_data'].set(adata.X)
+            else:
+                shared['X_data'].set(None)
+
+            if hasattr(adata, 'obs'):
+                shared['obs_data'].set(adata.obs)
+            else:
+                shared['obs_data'].set(None)
+
+            if hasattr(adata, 'obsm'):
+                shared['obsm_data'].set(adata.obsm)
+            else:
+                shared['obsm_data'].set(None)
+
+            if hasattr(adata, 'layers'):
+                shared['layers_data'].set(adata.layers)
+            else:
+                shared['layers_data'].set(None)
+
+            if hasattr(adata, 'var'):
+                shared['var_data'].set(adata.var)
+            else:
+                shared['var_data'].set(None)
+
+            if hasattr(adata, 'uns'):
+                shared['uns_data'].set(adata.uns)
+            else:
+                shared['uns_data'].set(None)
+
+            shared['shape_data'].set(adata.shape)
+
+            if hasattr(adata, 'obs'):
+                shared['obs_names'].set(list(adata.obs.keys()))
+            else:
+                shared['obs_names'].set(None)
+
+            if hasattr(adata, 'obsm'):
+                shared['obsm_names'].set(list(adata.obsm.keys()))
+            else:
+                shared['obsm_names'].set(None)
+
+            if hasattr(adata, 'layers'):
+                shared['layers_names'].set(list(adata.layers.keys()))
+            else:
+                shared['layers_names'].set(None)
+
+            if hasattr(adata, 'var'):
+                shared['var_names'].set(list(adata.var.index.tolist()))
+            else:
+                shared['var_names'].set(None)
+
+            if hasattr(adata, 'uns'):
+                shared['uns_names'].set(list(adata.uns.keys()))
+            else:
+                shared['uns_names'].set(None)
+
+            # Extract spatial distance columns
+            from utils.data_processing import get_spatial_distance_columns
+            spatial_cols = get_spatial_distance_columns(adata)
+            shared['spatial_distance_columns'].set(spatial_cols)
+        else:
+            # Clear all shared data if no AnnData loaded
+            shared['obs_data'].set(None)
+            shared['obsm_data'].set(None)
+            shared['layers_data'].set(None)
+            shared['var_data'].set(None)
+            shared['uns_data'].set(None)
+            shared['shape_data'].set(None)
+            shared['obs_names'].set(None)
+            shared['obsm_names'].set(None)
+            shared['layers_names'].set(None)
+            shared['var_names'].set(None)
+            shared['uns_names'].set(None)
+            shared['spatial_distance_columns'].set(None)
+
+    # ...existing render functions (print_obs_names, formatted_obs_names, etc.)...
+    # Keep all your existing @reactive.Calc and @render.text/ui functions
+    
+    @reactive.Calc
+    @render.text
+    def print_obs_names():
+        obs = shared['obs_names'].get()
+        if not obs:
+            return "Annotations: None"
+        if obs is not None:
+            if len(obs) > 1:
+                obs_str = ", ".join(obs)
+            else:
+                obs_str = obs[0] if obs else ""
+            return "Annotations: " + obs_str
+        else:
+            return "Empty"
+
+    @reactive.Calc
+    @render.text
+    def print_obsm_names():
+        obsm = shared['obsm_names'].get()
+        if not obsm:
+            return "Associated Tables: None"
+        if obsm is not None:
+            if len(obsm) > 1:
+                obsm_str = ", ".join(obsm)
+            else:
+                obsm_str = obsm[0] if obsm else ""
+            return "Associated Tables: " + obsm_str
+        else:
+            return "Empty"
+
+    @reactive.Calc
+    @render.text
+    def print_layers_names():
+        layers = shared['layers_names'].get()
+        if not layers:
+            return "Tables: None"
+        if len(layers) > 1:
+            layers_str = ", ".join(layers)
+        else:
+            layers_str = layers[0]
+        return "Tables: " + layers_str
+
+    @reactive.Calc
+    @render.text
+    def print_uns_names():
+        uns = shared['uns_names'].get()
+        if not uns:
+            return "Unstructured Data: None"
+        if uns is not None:
+            if len(uns) > 1:
+                uns_str = ", ".join(uns)
+            else:
+                uns_str = uns[0] if uns else ""
+            return "Unstructured Data: " + uns_str
+
+    @reactive.Calc
+    @render.text
+    def print_rows():
+        shape = shared['shape_data'].get()
+        if not shape:
+            return "None"
+        if shape is not None:
+            return str(shape[0])
+        else:
+            return "Empty"
+
+    @reactive.Calc
+    @render.text
+    def print_columns():
+        shape = shared['shape_data'].get()
+        if not shape:
+            return "None"
+        if shape is not None:
+            return str(shape[1])
+        else:
+            return "Empty"
+
+    @reactive.Calc
+    @render.ui
+    def formatted_obs_names():
+        from shiny import ui
+        obs = shared['obs_names'].get()
+        if not obs:
+            return ui.div("No annotations available", class_="text-muted")
+        if obs is not None and len(obs) > 0:
+            items = [
+                ui.div(
+                    ui.span("•", class_="metric-bullet"),
+                    ui.span(name, class_="metric-text"),
+                    class_="metric-item"
+                ) for name in obs
+            ]
+            return ui.div(*items)
+        else:
+            return ui.div("No data loaded", class_="text-muted")
+
+    @reactive.Calc
+    @render.ui
+    def formatted_obsm_names():
+        from shiny import ui
+        obsm = shared['obsm_names'].get()
+        if not obsm:
+            return ui.div("No associated tables available", class_="text-muted")
+        if obsm is not None and len(obsm) > 0:
+            items = [
+                ui.div(
+                    ui.span("•", class_="metric-bullet"),
+                    ui.span(name, class_="metric-text"),
+                    class_="metric-item"
+                ) for name in obsm
+            ]
+            return ui.div(*items)
+        else:
+            return ui.div("No data loaded", class_="text-muted")
+
+    @reactive.Calc
+    @render.ui
+    def formatted_layers_names():
+        from shiny import ui
+        layers = shared['layers_names'].get()
+        if not layers:
+            return ui.div("No tables available", class_="text-muted")
+        if layers is not None and len(layers) > 0:
+            items = [
+                ui.div(
+                    ui.span("•", class_="metric-bullet"),
+                    ui.span(name, class_="metric-text"),
+                    class_="metric-item"
+                ) for name in layers
+            ]
+            return ui.div(*items)
+        else:
+            return ui.div("No data loaded", class_="text-muted")
+
+    @reactive.Calc
+    @render.ui
+    def formatted_uns_names():
+        from shiny import ui
+        uns = shared['uns_names'].get()
+        if not uns:
+            return ui.div("No unstructured data available", class_="text-muted")
+        if uns is not None and len(uns) > 0:
+            items = [
+                ui.div(
+                    ui.span("•", class_="metric-bullet"),
+                    ui.span(name, class_="metric-text"),
+                    class_="metric-item"
+                ) for name in uns
+            ]
+            return ui.div(*items)
+        else:
+            return ui.div("No data loaded", class_="text-muted")
 
 
 def data_input_server(input, output, session, shared):

--- a/server/data_input_server.py
+++ b/server/data_input_server.py
@@ -10,11 +10,11 @@ def data_input_server(input, output, session, shared):
         file_info = input.input_file()
         if not file_info:
             # Only set preloaded data if it exists
-            if shared['preloaded_data'] is not None:
+            if shared['preloaded_data'] is None:
+                shared['data_loaded'].set(False)
+            else:
                 shared['adata_main'].set(shared['preloaded_data'])
                 shared['data_loaded'].set(True)
-            else:
-                shared['data_loaded'].set(False)
         else:
             file_path = file_info[0]['datapath']
             with open(file_path, 'rb') as file:
@@ -31,71 +31,7 @@ def data_input_server(input, output, session, shared):
     def update_parts():
         print("Updating Parts")
         adata = shared['adata_main'].get()
-        if adata is not None:
-
-            if hasattr(adata, 'X'):
-                shared['X_data'].set(adata.X)
-            else:
-                shared['X_data'].set(None)
-
-            if hasattr(adata, 'obs'):
-                shared['obs_data'].set(adata.obs)
-            else:
-                shared['obs_data'].set(None)
-
-            if hasattr(adata, 'obsm'):
-                shared['obsm_data'].set(adata.obsm)
-            else:
-                shared['obsm_data'].set(None)
-
-            if hasattr(adata, 'layers'):
-                shared['layers_data'].set(adata.layers)
-            else:
-                shared['layers_data'].set(None)
-
-            if hasattr(adata, 'var'):
-                shared['var_data'].set(adata.var)
-            else:
-                shared['var_data'].set(None)
-
-            if hasattr(adata, 'uns'):
-                shared['uns_data'].set(adata.uns)
-            else:
-                shared['uns_data'].set(None)
-
-            shared['shape_data'].set(adata.shape)
-
-            if hasattr(adata, 'obs'):
-                shared['obs_names'].set(list(adata.obs.keys()))
-            else:
-                shared['obs_names'].set(None)
-
-            if hasattr(adata, 'obsm'):
-                shared['obsm_names'].set(list(adata.obsm.keys()))
-            else:
-                shared['obsm_names'].set(None)
-
-            if hasattr(adata, 'layers'):
-                shared['layers_names'].set(list(adata.layers.keys()))
-            else:
-                shared['layers_names'].set(None)
-
-            if hasattr(adata, 'var'):
-                shared['var_names'].set(list(adata.var.index.tolist()))
-            else:
-                shared['var_names'].set(None)
-
-            if hasattr(adata, 'uns'):
-                shared['uns_names'].set(list(adata.uns.keys()))
-            else:
-                shared['uns_names'].set(None)
-
-            # Extract spatial_distance column names if available via helper
-            from utils.data_processing import get_spatial_distance_columns
-
-            spatial_cols = get_spatial_distance_columns(adata)
-            shared['spatial_distance_columns'].set(spatial_cols)
-        else:
+        if adata is None:
             shared['obs_data'].set(None)
             shared['obsm_data'].set(None)
             shared['layers_data'].set(None)
@@ -109,6 +45,70 @@ def data_input_server(input, output, session, shared):
             shared['uns_names'].set(None)
             shared['spatial_distance_columns'].set(None)
 
+        else:
+           if hasattr(adata, 'X'):
+               shared['X_data'].set(adata.X)
+           else:
+               shared['X_data'].set(None)
+
+           if hasattr(adata, 'obs'):
+               shared['obs_data'].set(adata.obs)
+           else:
+               shared['obs_data'].set(None)
+
+           if hasattr(adata, 'obsm'):
+               shared['obsm_data'].set(adata.obsm)
+           else:
+               shared['obsm_data'].set(None)
+
+           if hasattr(adata, 'layers'):
+               shared['layers_data'].set(adata.layers)
+           else:
+               shared['layers_data'].set(None)
+
+           if hasattr(adata, 'var'):
+               shared['var_data'].set(adata.var)
+           else:
+               shared['var_data'].set(None)
+
+           if hasattr(adata, 'uns'):
+               shared['uns_data'].set(adata.uns)
+           else:
+               shared['uns_data'].set(None)
+
+           shared['shape_data'].set(adata.shape)
+
+           if hasattr(adata, 'obs'):
+               shared['obs_names'].set(list(adata.obs.keys()))
+           else:
+               shared['obs_names'].set(None)
+
+           if hasattr(adata, 'obsm'):
+               shared['obsm_names'].set(list(adata.obsm.keys()))
+           else:
+               shared['obsm_names'].set(None)
+
+           if hasattr(adata, 'layers'):
+               shared['layers_names'].set(list(adata.layers.keys()))
+           else:
+               shared['layers_names'].set(None)
+
+           if hasattr(adata, 'var'):
+               shared['var_names'].set(list(adata.var.index.tolist()))
+           else:
+               shared['var_names'].set(None)
+
+           if hasattr(adata, 'uns'):
+               shared['uns_names'].set(list(adata.uns.keys()))
+           else:
+               shared['uns_names'].set(None)
+
+           # Extract spatial_distance column names if available via helper
+           from utils.data_processing import get_spatial_distance_columns
+
+           spatial_cols = get_spatial_distance_columns(adata)
+           shared['spatial_distance_columns'].set(spatial_cols)
+
 
     @reactive.Calc
     @render.text
@@ -116,14 +116,14 @@ def data_input_server(input, output, session, shared):
         obs = shared['obs_names'].get()
         if not obs:
             return "Annotations: None"
-        if obs is not None:
-            if len(obs) > 1:
-                obs_str = ", ".join(obs)
-            else:
-                obs_str = obs[0] if obs else ""
-            return "Annotations: " + obs_str
-        else:
+        if obs is None:
             return "Empty"
+        else:
+             if len(obs) > 1:
+                 obs_str = ", ".join(obs)
+             else:
+                 obs_str = obs[0] if obs else ""
+             return "Annotations: " + obs_str
         return
 
     @reactive.Calc
@@ -132,14 +132,15 @@ def data_input_server(input, output, session, shared):
         obsm = shared['obsm_names'].get()
         if not obsm:
             return "Associated Tables: None"
-        if obsm is not None:
+        if obsm is None:
+            return "Empty"
+        else:
+
             if len(obsm) > 1:
                 obsm_str = ", ".join(obsm)
             else:
                 obsm_str = obsm[0] if obsm else ""
             return "Associated Tables: " + obsm_str
-        else:
-            return "Empty"
         return
 
     @reactive.Calc
@@ -163,7 +164,9 @@ def data_input_server(input, output, session, shared):
         uns = shared['uns_names'].get()
         if not uns:
             return "Unstructured Data: None"
-        if uns is not None:
+        if uns is None:
+            return
+        else:
             if len(uns) > 1:
                 uns_str = ", ".join(uns)
             else:
@@ -177,10 +180,10 @@ def data_input_server(input, output, session, shared):
         shape = shared['shape_data'].get()
         if not shape:
             return "None"
-        if shape is not None:
-            return str(shape[0])
-        else:
+        if shape is None:
             return "Empty"
+        else:
+            return str(shape[0])
         return
 
     @reactive.Calc
@@ -189,10 +192,10 @@ def data_input_server(input, output, session, shared):
         shape = shared['shape_data'].get()
         if not shape:
             return "None"
-        if shape is not None:
-            return  str(shape[1])
-        else:
+        if shape is None:
             return "Empty"
+        else:
+            return  str(shape[1])
         return
 
     # Formatted UI outputs for better display
@@ -203,7 +206,9 @@ def data_input_server(input, output, session, shared):
         obs = shared['obs_names'].get()
         if not obs:
             return ui.div("No annotations available", class_="text-muted")
-        if obs is not None and len(obs) > 0:
+        if obs is None:
+           return ui.div("No data loaded", class_="text-muted")
+        elif len(obs) > 0:
             items = [
                 ui.div(
                     ui.span("•", class_="metric-bullet"),
@@ -212,8 +217,6 @@ def data_input_server(input, output, session, shared):
                 ) for name in obs
             ]
             return ui.div(*items)
-        else:
-            return ui.div("No data loaded", class_="text-muted")
 
     @reactive.Calc
     @render.ui
@@ -222,7 +225,9 @@ def data_input_server(input, output, session, shared):
         obsm = shared['obsm_names'].get()
         if not obsm:
             return ui.div("No associated tables available", class_="text-muted")
-        if obsm is not None and len(obsm) > 0:
+        if obsm is None:
+            return ui.div("No data loaded", class_="text-muted")
+        elif len(obsm) > 0:
             items = [
                 ui.div(
                     ui.span("•", class_="metric-bullet"),
@@ -231,8 +236,6 @@ def data_input_server(input, output, session, shared):
                 ) for name in obsm
             ]
             return ui.div(*items)
-        else:
-            return ui.div("No data loaded", class_="text-muted")
 
     @reactive.Calc
     @render.ui
@@ -241,7 +244,8 @@ def data_input_server(input, output, session, shared):
         layers = shared['layers_names'].get()
         if not layers:
             return ui.div("No tables available", class_="text-muted")
-        if layers is not None and len(layers) > 0:
+        if layers is None:
+            return ui.div("No data loaded", class_="text-muted")
             items = [
                 ui.div(
                     ui.span("•", class_="metric-bullet"),
@@ -250,8 +254,15 @@ def data_input_server(input, output, session, shared):
                 ) for name in layers
             ]
             return ui.div(*items)
-        else:
-            return ui.div("No data loaded", class_="text-muted")
+        elif len(layers) > 0:
+            items = [
+                ui.div(
+                    ui.span("•", class_="metric-bullet"),
+                    ui.span(name, class_="metric-text"),
+                    class_="metric-item"
+                ) for name in layers
+            ]
+            return ui.div(*items)
 
     @reactive.Calc
     @render.ui
@@ -260,14 +271,14 @@ def data_input_server(input, output, session, shared):
         uns = shared['uns_names'].get()
         if not uns:
             return ui.div("No unstructured data available", class_="text-muted")
-        if uns is not None and len(uns) > 0:
-            items = [
-                ui.div(
-                    ui.span("•", class_="metric-bullet"),
-                    ui.span(name, class_="metric-text"),
-                    class_="metric-item"
-                ) for name in uns
-            ]
-            return ui.div(*items)
-        else:
+        if uns is None:
             return ui.div("No data loaded", class_="text-muted")
+        elif len(uns) > 0:
+           items = [
+               ui.div(
+                   ui.span("•", class_="metric-bullet"),
+                   ui.span(name, class_="metric-text"),
+                   class_="metric-item"
+               ) for name in uns
+           ]
+           return ui.div(*items)

--- a/server/effect_update_server.py
+++ b/server/effect_update_server.py
@@ -160,7 +160,7 @@ def effect_update_server(input, output, session, shared):
         obsm = shared['obsm_names'].get()
         if not obsm:
             return "Associated Tables: None"
-        if obsm is not None:
+        if obsm:
             if len(obsm) > 1:
                 obsm_str = ", ".join(obsm)
             else:

--- a/server/effect_update_server.py
+++ b/server/effect_update_server.py
@@ -16,7 +16,7 @@ def effect_update_server(input, output, session, shared):
         choices = shared['var_names'].get()
         ui.update_select("h1_feat", choices=choices)
         ui.update_select("umap_feat", choices=choices)
-        if choices is not None:
+        if choices:
             ui.update_select("bp_features", choices=choices)
             ui.update_selectize("bp_features", selected=choices[:2])
 
@@ -24,14 +24,13 @@ def effect_update_server(input, output, session, shared):
     def update_select_input_anno():
         choices = shared['obs_names'].get()
         ui.update_select("bp_anno", choices=choices)
-        if choices is not None:
+        if choices:
             new_choices = choices + ["No Annotation"]
             ui.update_select("bp_anno", choices=new_choices)
         ui.update_select("h2_anno", choices=choices)
         ui.update_select("hm1_anno", choices=choices)
 
-        if choices is not None and len(choices) > 1:
-
+        if choices and len(choices) > 1:
             ui.update_select("sk1_anno1", choices=choices)
             ui.update_selectize("sk1_anno1", selected=choices[0])
             ui.update_select("sk1_anno2", choices=choices)
@@ -52,7 +51,7 @@ def effect_update_server(input, output, session, shared):
         # Get spatial_distance columns from shared state
         phenotype_choices = shared['spatial_distance_columns'].get()
 
-        if phenotype_choices is not None and len(phenotype_choices) > 0:
+        if phenotype_choices and len(phenotype_choices) > 0:
             # Update source label dropdown
             ui.update_select(
                 "nn_source_label",
@@ -78,7 +77,7 @@ def effect_update_server(input, output, session, shared):
 
     @reactive.Effect
     def update_select_input_layer():
-        if shared['layers_names'].get() is not None:
+        if shared['layers_names'].get():
             new_choices = shared['layers_names'].get() + ["Original"]
             ui.update_select("h1_layer", choices=new_choices)
             ui.update_select("bp_layer", choices=new_choices)
@@ -122,7 +121,7 @@ def effect_update_server(input, output, session, shared):
         if label_counts is None:
             return
 
-        if region_name is not None and region_name in label_counts:
+        if region_name and region_name in label_counts:
             # Use helper to fetch sorted labels for the region annotation
             from utils.data_processing import get_annotation_top_labels
 
@@ -234,7 +233,7 @@ def effect_update_server(input, output, session, shared):
         adata = shared['adata_main'].get()
         selected_anno = input.subset_anno_select()
 
-        if adata is not None and selected_anno:
+        if adata and selected_anno:
             labels = adata.obs[selected_anno].unique().tolist()
             print(f"Updating labels for {selected_anno}: {labels}")
             ui.update_selectize("subset_label_select", choices=labels)
@@ -243,7 +242,7 @@ def effect_update_server(input, output, session, shared):
     @reactive.event(input.go_subset, ignore_none=True)
     def subset_stratification():
         adata = shared['adata_main'].get()
-        if adata is not None:
+        if adata:
             annotation = input.subset_anno_select()
             labels = list(input.subset_label_select())
 
@@ -297,7 +296,7 @@ def effect_update_server(input, output, session, shared):
     def store_master_copy():
         """Store a master copy of the adata object when first loaded."""
         adata = shared['adata_main'].get()
-        if adata is not None and adata_master.get() is None:
+        if adata and adata_master.get() is None:
             # Make a copy of the adata object and store it as the master copy
             adata_master.set(adata.copy())
 
@@ -315,7 +314,7 @@ def effect_update_server(input, output, session, shared):
         Restore adata_main to the master copy stored in adata_master.
         """
         master_data = adata_master.get()
-        if master_data is not None:
+        if master_data:
             # Set adata_main to a copy of the master data to ensure
             # independence
             shared['adata_main'].set(master_data.copy())

--- a/server/feat_vs_anno_server.py
+++ b/server/feat_vs_anno_server.py
@@ -12,14 +12,14 @@ def feat_vs_anno_server(input, output, session, shared):
     def on_dendro_check():
         '''
         Check if dendrogram is enabled and return the appropriate values.
-        If dendrogram is enabled, 
+        If dendrogram is enabled,
             return a tuple (annotation dendrogram, feature dendrogram).
-        If dendrogram is disabled, 
+        If dendrogram is disabled,
             return (None, None) to indicate that no dendrogram is available.
         '''
         return (
-            (input.h2_anno_dendro(), input.h2_feat_dendro()) 
-            if input.dendogram() 
+            (input.h2_anno_dendro(), input.h2_feat_dendro())
+            if input.dendogram()
             else (None, None)
         )
 
@@ -28,35 +28,34 @@ def feat_vs_anno_server(input, output, session, shared):
     @reactive.event(input.go_hm1, ignore_none=True)
     def spac_Heatmap():
         adata = ad.AnnData(
-            X=shared['X_data'].get(), 
-            obs=pd.DataFrame(shared['obs_data'].get()), 
-            var=pd.DataFrame(shared['var_data'].get()), 
-            layers=shared['layers_data'].get(), 
+            X=shared['X_data'].get(),
+            obs=pd.DataFrame(shared['obs_data'].get()),
+            layers=shared['layers_data'].get(),
             dtype=shared['X_data'].get().dtype
         )
         if adata:
             vmin = input.min_select()
-            vmax = input.max_select()  
-            cmap = input.hm1_cmap()  # Get the selected color map from the dropdown 
-            kwargs = {"vmin": vmin,"vmax": vmax,} 
+            vmax = input.max_select()
+            cmap = input.hm1_cmap()  # Get the selected color map from the dropdown
+            kwargs = {"vmin": vmin,"vmax": vmax,}
 
             cluster_annotations, cluster_features = on_dendro_check()
             df, fig, ax = spac.visualization.hierarchical_heatmap(
-                adata, 
-                annotation=input.hm1_anno(), 
-                layer=on_layer_check(), 
-                z_score=None, 
+                adata,
+                annotation=input.hm1_anno(),
+                layer=on_layer_check(),
+                z_score=None,
                 cluster_annotations=cluster_annotations,
-                cluster_feature=cluster_features, 
+                cluster_feature=cluster_features,
                 **kwargs
             )
 
             # Only update if a non-default color map is selected
-            if cmap != "viridis":  
+            if cmap != "viridis":
                 fig.ax_heatmap.collections[0].set_cmap(cmap)
 
             shared['df_heatmap'].set(df)
-            
+
             # Rotate x-axis labels
             fig.ax_heatmap.set_xticklabels(
                 fig.ax_heatmap.get_xticklabels(),
@@ -69,7 +68,7 @@ def feat_vs_anno_server(input, output, session, shared):
             return fig
 
         return None
-    
+
     heatmap_ui_initialized = reactive.Value(False)
 
     @reactive.effect
@@ -102,7 +101,7 @@ def feat_vs_anno_server(input, output, session, shared):
     @render.download(filename="heatmap_data.csv")
     def download_df():
         df = shared['df_heatmap'].get()
-        if df is not None:
+        if df:
             csv_string = df.to_csv(index=False)
             csv_bytes = csv_string.encode("utf-8")
             return csv_bytes, "text/csv"
@@ -121,9 +120,9 @@ def feat_vs_anno_server(input, output, session, shared):
     @reactive.event(input.hm1_layer)
     def update_min_max():
         adata = ad.AnnData(
-            X=shared['X_data'].get(), 
-            obs=pd.DataFrame(shared['obs_data'].get()), 
-            var=pd.DataFrame(shared['var_data'].get()), 
+            X=shared['X_data'].get(),
+            obs=pd.DataFrame(shared['obs_data'].get()),
+            var=pd.DataFrame(shared['var_data'].get()),
             layers=shared['layers_data'].get()
         )
         if input.hm1_layer() == "Original":
@@ -139,10 +138,10 @@ def feat_vs_anno_server(input, output, session, shared):
         ui.remove_ui("#inserted-max_num")
 
         min_num = ui.input_numeric(
-            "min_select", 
-            "Minimum", 
-            min_val, 
-            min=min_val, 
+            "min_select",
+            "Minimum",
+            min_val,
+            min=min_val,
             max=max_val
         )
         ui.insert_ui(
@@ -150,12 +149,12 @@ def feat_vs_anno_server(input, output, session, shared):
             selector="#main-min_num",
             where="beforeEnd",
         )
-        
+
         max_num = ui.input_numeric(
-            "max_select", 
-            "Maximum", 
-            max_val, 
-            min=min_val, 
+            "max_select",
+            "Maximum",
+            max_val,
+            min=min_val,
             max=max_val
         )
         ui.insert_ui(

--- a/server/feat_vs_anno_server.py
+++ b/server/feat_vs_anno_server.py
@@ -34,7 +34,7 @@ def feat_vs_anno_server(input, output, session, shared):
             layers=shared['layers_data'].get(), 
             dtype=shared['X_data'].get().dtype
         )
-        if adata is not None:
+        if adata:
             vmin = input.min_select()
             vmax = input.max_select()  
             cmap = input.hm1_cmap()  # Get the selected color map from the dropdown 

--- a/server/features_server.py
+++ b/server/features_server.py
@@ -60,7 +60,7 @@ def features_server(input, output, session, shared):
     @render.download(filename="features_histogram_data.csv")
     def download_histogram1_df():
         df = shared['df_histogram1'].get()
-        if df is not None:
+        if df:
             csv_string = df.to_csv(index=False)
             csv_bytes = csv_string.encode("utf-8")
             return csv_bytes, "text/csv"

--- a/server/features_server.py
+++ b/server/features_server.py
@@ -15,10 +15,10 @@ def features_server(input, output, session, shared):
     @reactive.event(input.go_h1, ignore_none=True)
     def spac_Histogram_1():
         adata = ad.AnnData(
-            X=shared['X_data'].get(), 
-            obs=pd.DataFrame(shared['obs_data'].get()), 
-            var=pd.DataFrame(shared['var_data'].get()), 
-            layers=shared['layers_data'].get(), 
+            X=shared['X_data'].get(),
+            obs=pd.DataFrame(shared['obs_data'].get()),
+            var=pd.DataFrame(shared['var_data'].get()),
+            layers=shared['layers_data'].get(),
             dtype=shared['X_data'].get().dtype
         )
 
@@ -44,7 +44,7 @@ def features_server(input, output, session, shared):
             kwargs["together"] = input.h1_together_check()
             if input.h1_together_check():
                 kwargs["multiple"] = input.h1_together_drop()
-        
+
         fig1, ax, df = spac.visualization.histogram(**kwargs).values()
 
         axes = ax if isinstance(ax, (list, np.ndarray)) else [ax]
@@ -70,10 +70,10 @@ def features_server(input, output, session, shared):
     @render.ui
     @reactive.event(input.go_h1, ignore_none=True)
     def download_histogram1_button_ui():
-        if shared['df_histogram1'].get() is not None:
+        if shared['df_histogram1'].get():
             return ui.download_button(
-                "download_histogram1_df", 
-                "Download Data", 
+                "download_histogram1_df",
+                "Download Data",
                 class_="btn-warning"
             )
         return None
@@ -86,8 +86,8 @@ def features_server(input, output, session, shared):
 
         if btn and not ui_initialized:
             dropdown = ui.input_select(
-                "h1_anno", 
-                "Select an Annotation", 
+                "h1_anno",
+                "Select an Annotation",
                 choices=shared['obs_names'].get()
             )
             ui.insert_ui(
@@ -97,8 +97,8 @@ def features_server(input, output, session, shared):
             )
 
             together_check = ui.input_checkbox(
-                "h1_together_check", 
-                "Plot Together", 
+                "h1_together_check",
+                "Plot Together",
                 value=True
             )
             ui.insert_ui(
@@ -121,17 +121,17 @@ def features_server(input, output, session, shared):
     def update_stack_type_dropdown():
         if input.h1_together_check():
             dropdown_together = ui.input_select(
-                "h1_together_drop", 
-                "Select Stack Type", 
-                choices=['stack', 'layer', 'dodge', 'fill'], 
+                "h1_together_drop",
+                "Select Stack Type",
+                choices=['stack', 'layer', 'dodge', 'fill'],
                 selected='stack'
             )
             ui.insert_ui(
                 ui.div(
-                    {"id": "inserted-dropdown_together"}, 
+                    {"id": "inserted-dropdown_together"},
                     dropdown_together
                 ),
                 selector="#main-h1_together_drop",
-                where="beforeEnd",)      
+                where="beforeEnd",)
         else:
             ui.remove_ui("#inserted-dropdown_together")

--- a/server/nearest_neighbor_server.py
+++ b/server/nearest_neighbor_server.py
@@ -88,14 +88,14 @@ def nearest_neighbor_server(input, output, session, shared):
         """
         adata = get_adata()
         choices = {"None": "None (Auto)"}
-        
+
         if adata:
             # Extract available color mappings from uns
             if hasattr(adata, 'uns') and adata.uns is not None:
                 for key in adata.uns.keys():
                     if key.endswith('_color_map') or 'color' in key.lower():
                         choices[key] = key
-        
+
         return ui.input_select(
             "nn_color_mapping",
             ui.tags.span(
@@ -144,21 +144,21 @@ def nearest_neighbor_server(input, output, session, shared):
         # Auto-detect annotation column matching spatial_distance phenotypes
         annotation = None
         spatial_distance_key = "spatial_distance"  # Use hardcoded default
-        
+
         # Check if spatial distance data is in obsm or uns
         distance_df = None
         if spatial_distance_key in adata.obsm:
             distance_df = adata.obsm[spatial_distance_key]
         elif spatial_distance_key in adata.uns:
             distance_df = adata.uns[spatial_distance_key]
-        
+
         if distance_df and hasattr(distance_df, 'columns'):
             spatial_phenotypes = set(distance_df.columns)
-            
+
             # Find annotation column that contains matching phenotypes
             for col in adata.obs.columns:
                 is_categorical = (adata.obs[col].dtype == 'object' or
-                                  adata.obs[col].dtype.name == 'category')
+                                adata.obs[col].dtype.name == 'category')
                 if is_categorical:
                     obs_phenotypes = set(adata.obs[col].unique())
                     # Check if there's significant overlap (80%+)
@@ -167,7 +167,7 @@ def nearest_neighbor_server(input, output, session, shared):
                     if len(overlap) >= len(spatial_phenotypes) * 0.8:
                         annotation = col
                         break
-            
+
             if annotation is None:
                 # Fallback: use the first categorical column
                 for col in adata.obs.columns:
@@ -199,7 +199,7 @@ def nearest_neighbor_server(input, output, session, shared):
                 "Annotation": annotation,
                 "Source_Anchor_Cell_Label": source_label,
                 "Target_Cell_Label": (",".join(target_labels)
-                                      if target_labels else "All"),
+                                    if target_labels else "All"),
                 "ImageID": image_id or "None",
                 "Plot_Method": input.nn_plot_method(),
                 "Plot_Type": get_plot_type(),
@@ -209,8 +209,8 @@ def nearest_neighbor_server(input, output, session, shared):
                 "X_Axis_Label_Rotation": input.nn_x_axis_rotation(),
                 "Shared_X_Axis_Title_": input.nn_shared_x_title(),
                 "X_Axis_Title_Font_Size": (input.nn_x_title_fontsize()
-                                           if input.nn_x_title_fontsize()
-                                           else "None"),
+                                        if input.nn_x_title_fontsize()
+                                        else "None"),
                 "Defined_Color_Mapping": get_color_mapping() or "None",
                 "Figure_Width": input.nn_figure_width(),
                 "Figure_Height": input.nn_figure_height(),

--- a/server/nearest_neighbor_server.py
+++ b/server/nearest_neighbor_server.py
@@ -89,7 +89,7 @@ def nearest_neighbor_server(input, output, session, shared):
         adata = get_adata()
         choices = {"None": "None (Auto)"}
         
-        if adata is not None:
+        if adata:
             # Extract available color mappings from uns
             if hasattr(adata, 'uns') and adata.uns is not None:
                 for key in adata.uns.keys():
@@ -152,7 +152,7 @@ def nearest_neighbor_server(input, output, session, shared):
         elif spatial_distance_key in adata.uns:
             distance_df = adata.uns[spatial_distance_key]
         
-        if distance_df is not None and hasattr(distance_df, 'columns'):
+        if distance_df and hasattr(distance_df, 'columns'):
             spatial_phenotypes = set(distance_df.columns)
             
             # Find annotation column that contains matching phenotypes
@@ -263,7 +263,7 @@ def nearest_neighbor_server(input, output, session, shared):
             CSV bytes and content type
         """
         df = shared['df_nn'].get()
-        if df is not None:
+        if df:
             csv_string = df.to_csv(index=False)
             csv_bytes = csv_string.encode("utf-8")
             return csv_bytes, "text/csv"
@@ -280,7 +280,7 @@ def nearest_neighbor_server(input, output, session, shared):
         shiny.ui element or None
             Download button UI or None if no data
         """
-        if shared['df_nn'].get() is not None:
+        if shared['df_nn'].get():
             return ui.download_button(
                 "download_df_nn",
                 "Download Data",

--- a/server/ripleyL_server.py
+++ b/server/ripleyL_server.py
@@ -107,7 +107,7 @@ def ripleyL_server(input, output, session, shared):
     @render.download(filename="ripley_plot_data.csv")
     def download_df_rl():
         df = shared['df_ripley'].get()
-        if df is not None:
+        if df:
             csv_string = df.to_csv(index=False)
             csv_bytes = csv_string.encode("utf-8")
             return csv_bytes, "text/csv"
@@ -116,7 +116,7 @@ def ripleyL_server(input, output, session, shared):
     @render.ui
     @reactive.event(input.go_rl, ignore_none=True)
     def download_button_ui_rl():
-        if shared['df_ripley'].get() is not None:
+        if shared['df_ripley'].get():
             return ui.download_button(
                 "download_df_rl",
                 "Download Data",

--- a/server/scatterplot_server.py
+++ b/server/scatterplot_server.py
@@ -83,8 +83,8 @@ def scatterplot_server(input, output, session, shared):
         if btn and not scatter_ui_initialized.get():
             # Insert the color selection dropdown if not already initialized
             dropdown = ui.input_select(
-                "scatter_color", 
-                "Select Feature", 
+                "scatter_color",
+                "Select Feature",
                 choices=shared['var_names'].get()
             )
             ui.insert_ui(
@@ -104,14 +104,14 @@ def scatterplot_server(input, output, session, shared):
         if selected_feature is None:
             return None
         adata = ad.AnnData(
-            X=shared['X_data'].get(), 
+            X=shared['X_data'].get(),
             var=pd.DataFrame(shared['var_data'].get())
         )
         if selected_feature in adata.var_names:
             column_index = adata.var_names.get_loc(selected_feature)
             color_values = adata.X[:, column_index]
             return color_values
-        return None 
+        return None
 
     @output
     @render.plot

--- a/server/spatial_server.py
+++ b/server/spatial_server.py
@@ -15,8 +15,8 @@ def spatial_server(input, output, session, shared):
 
         if btn and not ui_initialized:
             dropdown_slide = ui.input_select(
-                "slide_select_drop", 
-                "Select the Slide Annotation", 
+                "slide_select_drop",
+                "Select the Slide Annotation",
                 choices=shared['obs_names'].get())
             ui.insert_ui(
                 ui.div({"id": "inserted-slide_dropdown"}, dropdown_slide),
@@ -25,8 +25,8 @@ def spatial_server(input, output, session, shared):
             )
 
             dropdown_label = ui.input_select(
-                "slide_select_label", 
-                "Select a Slide", 
+                "slide_select_label",
+                "Select a Slide",
                 choices=[]
             )
             ui.insert_ui(
@@ -58,8 +58,8 @@ def spatial_server(input, output, session, shared):
 
         if btn and not ui_initialized:
             dropdown_region = ui.input_select(
-                "region_select_drop", 
-                "Select the Region Annotation", 
+                "region_select_drop",
+                "Select the Region Annotation",
                 choices=shared['obs_names'].get())
             ui.insert_ui(
                 ui.div({"id": "inserted-region_dropdown"}, dropdown_region),
@@ -68,13 +68,13 @@ def spatial_server(input, output, session, shared):
             )
 
             dropdown_label = ui.input_select(
-                "region_label_select", 
+                "region_label_select",
                 "Select a Region",
                 choices=[]
             )
             ui.insert_ui(
                 ui.div(
-                    {"id": "inserted-region_label_select_dropdown"}, 
+                    {"id": "inserted-region_label_select_dropdown"},
                     dropdown_label
                 ),
                 selector="#main-region_label_select_dropdown",
@@ -100,11 +100,11 @@ def spatial_server(input, output, session, shared):
     @reactive.event(input.go_sp1, ignore_none=True)
     def spac_Spatial():
         adata = ad.AnnData(
-            X=shared['X_data'].get(), 
-            var=pd.DataFrame(shared['var_data'].get()), 
-            obsm=shared['obsm_data'].get(), 
-            obs=shared['obs_data'].get(), 
-            dtype=shared['X_data'].get().dtype, 
+            X=shared['X_data'].get(),
+            var=pd.DataFrame(shared['var_data'].get()),
+            obsm=shared['obsm_data'].get(),
+            obs=shared['obs_data'].get(),
+            dtype=shared['X_data'].get().dtype,
             layers=shared['layers_data'].get()
         )
         slide_check = input.slide_select_check()
@@ -139,7 +139,7 @@ def spatial_server(input, output, session, shared):
                 if "spatial_feat" not in input or input.spatial_feat() is None:
                     return None
                 layer = (
-                    None if input.spatial_layer() == "Original" 
+                    None if input.spatial_layer() == "Original"
                     else input.spatial_layer()
                 )
                 out = spac.visualization.interactive_spatial_plot(
@@ -163,25 +163,25 @@ def spatial_server(input, output, session, shared):
             else:
                 return None
             out[0]['image_object'].update_xaxes(
-                showticklabels=True, 
-                ticks="outside", 
-                tickwidth=2, 
+                showticklabels=True,
+                ticks="outside",
+                tickwidth=2,
                 ticklen=10
             )
             out[0]['image_object'].update_yaxes(
-                showticklabels=True, 
-                ticks="outside", 
-                tickwidth=2, 
+                showticklabels=True,
+                ticks="outside",
+                tickwidth=2,
                 ticklen=10
             )
             return out[0]['image_object']
 
         return None
 
-    #Track UI State 
+    #Track UI State
     spatial_annotation_initialized = reactive.Value(False)
     spatial_feature_initialized = reactive.Value(False)
-   
+
     @reactive.effect
     def spatial_reactivity():
         flipper = shared['data_loaded'].get()
@@ -211,8 +211,8 @@ def spatial_server(input, output, session, shared):
             elif btn == "Feature":
                 if not spatial_feature_initialized.get():
                     dropdown = ui.input_select(
-                        "spatial_feat", 
-                        "Select a Feature", 
+                        "spatial_feat",
+                        "Select a Feature",
                         choices=shared['var_names'].get()
                     )
                     ui.insert_ui(
@@ -223,8 +223,8 @@ def spatial_server(input, output, session, shared):
                         where="beforeEnd"
                     )
                     table_select = ui.input_select(
-                        "spatial_layer", 
-                        "Select a Table", 
+                        "spatial_layer",
+                        "Select a Table",
                         choices=shared['layers_names'].get() + ["Original"],
                         selected="Original"
                     )

--- a/server/spatial_server.py
+++ b/server/spatial_server.py
@@ -109,7 +109,7 @@ def spatial_server(input, output, session, shared):
         )
         slide_check = input.slide_select_check()
         region_check = input.region_select_check()
-        if adata is not None:
+        if adata:
             if slide_check is False and region_check is False:
                 adata_subset = adata
             elif slide_check is True and region_check is False:
@@ -185,7 +185,7 @@ def spatial_server(input, output, session, shared):
     @reactive.effect
     def spatial_reactivity():
         flipper = shared['data_loaded'].get()
-        if flipper is not False:
+        if flipper:
             btn = input.spatial_rb()
 
             if btn == "Annotation":

--- a/server/umap_server.py
+++ b/server/umap_server.py
@@ -61,7 +61,7 @@ def umap_server(input, output, session, shared):
     @reactive.effect
     def umap_reactivity():
         flipper = shared['data_loaded'].get()
-        if flipper is not False:
+        if flipper:
             btn = input.umap_rb()
 
             if btn == "Annotation":
@@ -186,7 +186,7 @@ def umap_server(input, output, session, shared):
     @reactive.effect
     def umap_reactivity2():
         flipper = shared['data_loaded'].get()
-        if flipper is not False:
+        if flipper:
             btn = input.umap_rb2()
 
             if btn == "Annotation":

--- a/server/umap_server.py
+++ b/server/umap_server.py
@@ -63,13 +63,12 @@ def umap_server(input, output, session, shared):
         flipper = shared['data_loaded'].get()
         if flipper:
             btn = input.umap_rb()
-
             if btn == "Annotation":
                 if not umap_annotation_initialized.get():
                     # Create the Annotation dropdown
                     dropdown = ui.input_select(
-                        "umap_rb_anno", 
-                        "Select an Annotation", 
+                        "umap_rb_anno",
+                        "Select an Annotation",
                         choices=shared['obs_names'].get(),
                     )
                     ui.insert_ui(
@@ -89,8 +88,8 @@ def umap_server(input, output, session, shared):
                 if not umap_feature_initialized.get():
                     # Create the Feature dropdown
                     dropdown1 = ui.input_select(
-                        "umap_rb_feat", 
-                        "Select a Feature", 
+                        "umap_rb_feat",
+                        "Select a Feature",
                         choices=shared['var_names'].get()
                     )
                     ui.insert_ui(
@@ -102,9 +101,9 @@ def umap_server(input, output, session, shared):
                     # Create the Table dropdown
                     new_choices = shared['layers_names'].get() + ["Original"]
                     table_umap = ui.input_select(
-                        "umap_layer", 
-                        "Select a Table", 
-                        choices=new_choices, 
+                        "umap_layer",
+                        "Select a Table",
+                        choices=new_choices,
                         selected=["Original"]
                     )
                     ui.insert_ui(
@@ -192,8 +191,8 @@ def umap_server(input, output, session, shared):
             if btn == "Annotation":
                 if not umap2_annotation_initialized.get():
                     dropdown = ui.input_select(
-                        "umap_rb_anno2", 
-                        "Select an Annotation", 
+                        "umap_rb_anno2",
+                        "Select an Annotation",
                         choices=shared['obs_names'].get()
                     )
                     ui.insert_ui(
@@ -210,8 +209,8 @@ def umap_server(input, output, session, shared):
             elif btn == "Feature":
                 if not umap2_feature_initialized.get():
                     dropdown1 = ui.input_select(
-                        "umap_rb_feat2", 
-                        "Select a Feature", 
+                        "umap_rb_feat2",
+                        "Select a Feature",
                         choices=shared['var_names'].get()
                     )
                     ui.insert_ui(

--- a/ui/anno_vs_anno_ui.py
+++ b/ui/anno_vs_anno_ui.py
@@ -96,6 +96,10 @@ def anno_vs_anno_ui():
                             "go_sk1",
                             "Generate Sankey Plot",
                             class_="btn-success"
+                        ),
+                        ui.div(
+                            {"style": "padding-top: 20px;"},
+                            ui.output_ui("download_button_ui_sankey")
                         )
                     ),
                     ui.column(


### PR DESCRIPTION
## HTML Download

### Description:

Boxplot and Sankey diagrams can now be downloaded as interactive HTML files 

### Problems:

### Changes:

App.py:  Two new shared variables were added to store Sankey and boxplot figures so that the app can reuse the same figure for display and HTML downloading 

Server/anno_vs_anno_server.py, server/boxplot_server.py: Now when a Sankey/boxplot Plotly figure is generated, the code saves it to a shared variable, and a download handler is present 

Server/data_input_server.py: A helper function was added to sanitize file names and the cleaned file name is stored in a shared variable.  

UI/...: Buttons added for downloading 

### Areas for Improvement: 

The UI may be inconsistent now between graphs that can be downloaded as an HTML file and those that cannot
## Code cleanup/ if-not hacks and flipper variable

### Description:
 When originally created, there was a bug in Shiny for Python that crashed the program when a statement like the example below was used: 

If x is True: # or "If x” implying the boolean check.  
       Run Code A 
Else: 
      Run Code B 

In order to get around that, the original coder used not statements to flip logic and get around the crashes: 

If x is not False:  # not False is essentially True 
      Run Code A 
Else: 
           Run Code B 

However, with recent updates to Shiny this issue was fixed, and standard if statements will no longer crash the program. In this PR, we went through the entire code and changed all if-not hacks to follow standard conventions.  
The flipper variable was a redundant variable that could be cut out without affecting program performance. Getting rid of it helped declutter the code and improve readability. 

### Problems: 
This change affects multiple files and could have merge conflicts with the main branch 

### Changes: 
Changed all if-not logic to follow normal/standard logic flow. Removed flipper variable. 

## Caching Dataset to increase efficiency

### Description:

Since plot caching would require core refactoring of the codebase and due to the limited time we had at the end of the semester, we decided to go with Dataset caching instead. 

We could visibly observe the improvement of loading times for majority of the types of plots on the SPAC Shiny app. 

Majority of the logistics are done through the cached_load_data(file_path) function, which first checks if the file is cached, and caches into _data_cache dictionary if not already cached. 

The data_input_server module uses the caching functions to load data. It handles: User file uploads (.h5ad and .pickle files), Preloaded dataset selection from dropdowns, Coordinating which data source to use (uploaded vs. preloaded) 

### Problems:

.pickle file caching is still unstable, compared to .h5ad files 

### Changes:

data_processing.py and data_input_server.py 

Areas for Improvement 

Need to quantify the loading times to see exactly how much loading times have improved by 

 

 