### PR TITLE
Fix: Enable hot-reloading for Shiny app in Docker dev mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,11 +45,10 @@ run: build
 
 # Run with development volume mount
 run-dev: build
-	@echo "Starting SPAC Shiny container in development mode..."
+	@echo "Starting SPAC Shiny container in development mode (with auto-reload)..."
 	@echo "App will be available at: http://localhost:8001"
-	docker run -d --name spac-shiny-app -p 8001:8000 -v $(PWD):/app spac-shiny
-
-
+	docker run -d --name spac-shiny-app -p 8001:8000 -v $(PWD):/app spac-shiny \
+		python -m shiny run app.py --host 0.0.0.0 --port 8000 --reload
 
 # Stop the container
 stop:


### PR DESCRIPTION
## Description

Enables hot-reloading of the Shiny app when running in Docker development mode (`make run-dev`), so developers can see code changes immediately by refreshing the browser — without restarting the container.

Closes https://github.com/Saran-Nag/SPAC_Shiny-Purdue-2025/issues/28

This PR is drafted by copilot.

## Problem

Previously, developers had to run `make stop` + `make run` (or `make restart`) to reflect any code changes. This led to:

- **Loss of persistence** — Rebuilding clears all container state including logs, complicating debugging.
- **Time-intensive rebuilds** — Any environment or dependency change (especially within the `spac` package) triggers a full rebuild that can take 5+ minutes.

## Solution

Modified the `run-dev` target in the `Makefile` to override the container's default `CMD` with the `--reload` flag:

```makefile
run-dev: build
    @echo "Starting SPAC Shiny container in development mode (with auto-reload)..."
    @echo "App will be available at: http://localhost:8001"
    docker run -d --name spac-shiny-app -p 8001:8000 -v $(PWD):/app spac-shiny \
        python -m shiny run app.py --host 0.0.0.0 --port 8000 --reload
```

This works because `make run-dev` already mounts the local working directory into the container (`-v $(PWD):/app`). Adding `--reload` tells the Shiny server to watch for file changes and automatically restart. This gives us:

- **Instant code updates** — Refresh the browser to see changes immediately.
- **Fast package testing** — Install packages inside the container via `make shell` without rebuilding.

The production `run` target and `Dockerfile` are **unchanged**.

## Changes

- **`Makefile`** — Updated `run-dev` target to pass `--reload` flag to the Shiny server command.

## Testing

- [x] `make run-dev` starts the app with `--reload` mode enabled
- [x] Modified source files and confirmed changes are reflected in the browser after refresh
- [x] `make run` (production mode) is unaffected