### PR TITLE
refactor: feat_vs_anno_server to use run_from_json pattern

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -85,5 +85,5 @@ dependencies:
       - shapely==2.0.7  # To be consistent with requirement.txt
       - sag-py-execution-time-decorator @ git+https://github.com/SamhammerAG/sag_py_execution_time_decorator.git@976c9683d561aadc0166495117c42cc1762633d7
       # SPAC package pinned to specific commit for template compatibility (dev branch as of 2026-03-16)
-      - spac @ git+https://github.com/FNLCR-DMAP/SCSAWorkflow.git@598517d#egg=spac
+      - spac @ git+https://github.com/FNLCR-DMAP/SCSAWorkflow.git@4bd1aafe9540f219982e468a43808b8bda837c00#egg=spac
 

--- a/environment.yml
+++ b/environment.yml
@@ -1,10 +1,10 @@
-# Warning: 
+# Warning:
 # This file may be outdated. See requirements.txt to get the latest dependencies.
 
 # Quick Start:
 # This is a file for conda users. For general users, you may use docker instead.
 # 1. Create and activate the conda environment with this file in the usual way.
-# 2. Run 'shiny run --reload app.py' in the terminal. 
+# 2. Run 'shiny run --reload app.py' in the terminal.
 # The app will be available at http://127.0.0.1:8000.
 
 # Special Reminder for macOS (MacArm64) users:
@@ -37,9 +37,9 @@ dependencies:
   - scikit-image=0.19.3
   - scipy=1.10.1
   # For macOS (MacArm64) users, uncomment the following three lines
-  # - tables>=3.8.0
-  # - c-blosc2
-  # - libtiff
+  - tables>=3.8.0
+  - c-blosc2
+  - libtiff
   - pip
   - pip:
       - ipykernel==6.29.5
@@ -72,7 +72,7 @@ dependencies:
       - shinyswatch==0.6.1
       - shinywidgets==0.7.0
       - sinfo==0.3.4
-      - tables==3.8.0   # For macOS (MacArm64) users, comment out this line.
+      # - tables==3.8.0   # For macOS (MacArm64) users, comment out this line.
       - tinycss2==1.3.0
       - tqdm==4.66.4
       - typeguard==4.3.0
@@ -84,6 +84,6 @@ dependencies:
       - tifffile
       - shapely==2.0.7  # To be consistent with requirement.txt
       - sag-py-execution-time-decorator @ git+https://github.com/SamhammerAG/sag_py_execution_time_decorator.git@976c9683d561aadc0166495117c42cc1762633d7
-      # SPAC package pinned to specific commit for template compatibility (dev branch as of 2025-10-15)
-      - spac @ git+https://github.com/FNLCR-DMAP/SCSAWorkflow.git@c2a248826b91880c62308e85e60cae9361c275d0#egg=spac
+      # SPAC package pinned to specific commit for template compatibility (dev branch as of 2026-03-16)
+      - spac @ git+https://github.com/FNLCR-DMAP/SCSAWorkflow.git@598517d#egg=spac
 

--- a/environment.yml
+++ b/environment.yml
@@ -37,9 +37,9 @@ dependencies:
   - scikit-image=0.19.3
   - scipy=1.10.1
   # For macOS (MacArm64) users, uncomment the following three lines
-  - tables>=3.8.0
-  - c-blosc2
-  - libtiff
+  # - tables>=3.8.0
+  # - c-blosc2
+  # - libtiff
   - pip
   - pip:
       - ipykernel==6.29.5
@@ -84,6 +84,6 @@ dependencies:
       - tifffile
       - shapely==2.0.7  # To be consistent with requirement.txt
       - sag-py-execution-time-decorator @ git+https://github.com/SamhammerAG/sag_py_execution_time_decorator.git@976c9683d561aadc0166495117c42cc1762633d7
-      # SPAC package pinned to specific commit for template compatibility (dev branch as of 2026-03-16)
+      # SPAC package pinned to specific commit for template compatibility (main branch as of 2026-03-18)
       - spac @ git+https://github.com/FNLCR-DMAP/SCSAWorkflow.git@4bd1aafe9540f219982e468a43808b8bda837c00#egg=spac
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -53,4 +53,4 @@ tifffile
 shapely==2.0.7
 sag-py-execution-time-decorator @ git+https://github.com/SamhammerAG/sag_py_execution_time_decorator.git@976c9683d561aadc0166495117c42cc1762633d7
 # SPAC package pinned to specific commit for template compatibility (dev branch as of 2026-03-16)
-spac @ git+https://github.com/FNLCR-DMAP/SCSAWorkflow.git@598517d#egg=spac
+spac @ git+https://github.com/FNLCR-DMAP/SCSAWorkflow.git@4bd1aafe9540f219982e468a43808b8bda837c00#egg=spac

--- a/requirements.txt
+++ b/requirements.txt
@@ -52,5 +52,5 @@ zipp==3.19.2
 tifffile
 shapely==2.0.7
 sag-py-execution-time-decorator @ git+https://github.com/SamhammerAG/sag_py_execution_time_decorator.git@976c9683d561aadc0166495117c42cc1762633d7
-# SPAC package pinned to specific commit for template compatibility (dev branch as of 2026-03-16)
+# SPAC package pinned to specific commit for template compatibility (main branch as of 2026-03-18)
 spac @ git+https://github.com/FNLCR-DMAP/SCSAWorkflow.git@4bd1aafe9540f219982e468a43808b8bda837c00#egg=spac

--- a/requirements.txt
+++ b/requirements.txt
@@ -52,5 +52,5 @@ zipp==3.19.2
 tifffile
 shapely==2.0.7
 sag-py-execution-time-decorator @ git+https://github.com/SamhammerAG/sag_py_execution_time_decorator.git@976c9683d561aadc0166495117c42cc1762633d7
-# SPAC package pinned to specific commit for template compatibility (dev branch as of 2025-10-15)
-spac @ git+https://github.com/FNLCR-DMAP/SCSAWorkflow.git@c2a248826b91880c62308e85e60cae9361c275d0#egg=spac
+# SPAC package pinned to specific commit for template compatibility (dev branch as of 2026-03-16)
+spac @ git+https://github.com/FNLCR-DMAP/SCSAWorkflow.git@598517d#egg=spac

--- a/server/feat_vs_anno_server.py
+++ b/server/feat_vs_anno_server.py
@@ -48,6 +48,22 @@ def feat_vs_anno_server(input, output, session, shared):
         """Get the main AnnData object from shared state."""
         return shared['adata_main'].get()
 
+    @render.ui
+    def hm1_features_ui():
+        """Create dynamic feature multi-select from loaded data."""
+        adata = get_adata()
+        if adata is None:
+            return None
+
+        feature_choices = ["All"] + sorted(adata.var_names.tolist())
+        return ui.input_selectize(
+            "hm1_features",
+            "Feature(s)",
+            choices=feature_choices,
+            selected=["All"],
+            multiple=True
+        )
+
     @reactive.calc
     def get_layer():
         """
@@ -128,27 +144,34 @@ def feat_vs_anno_server(input, output, session, shared):
             virtual_path = register_memory_object(adata)
 
             params = {
+                # Core parameters
                 "Upstream_Analysis": virtual_path,
                 "Annotation": annotation,
                 "Table_to_Visualize": layer,
-                "Feature_s_": ["All"],
-                "Standard_Scale_": "None",
-                "Z_Score": "None",
+                "Feature_s_": list(input.hm1_features()) if input.hm1_features() else ["All"],
                 "Feature_Dendrogram": cluster_features,
                 "Annotation_Dendrogram": cluster_annotations,
-                "Figure_Title": "Hierarchical Heatmap",
-                "Figure_Width": 8,
-                "Figure_Height": 8,
-                "Figure_DPI": 300,
-                "Font_Size": 10,
-                "Matrix_Plot_Ratio": 0.8,
-                "Swap_Axes": False,
+
+                # Plot configuration — read from UI inputs
+                "Z_Score": input.hm1_z_score(),
+                "Standard_Scale_": input.hm1_standard_scale(),
+                "Swap_Axes": input.hm1_swap_axes(),
+                "Color_Map": cmap,
+                "Value_Min": vmin,
+                "Value_Max": vmax,
+
+                # Figure configuration — read from UI inputs
+                "Figure_Title": input.hm1_figure_title(),
+                "Figure_Width": input.hm1_figure_width(),
+                "Figure_Height": input.hm1_figure_height(),
+                "Figure_DPI": input.hm1_figure_dpi(),
+                "Font_Size": input.hm1_font_size(),
+                "Matrix_Plot_Ratio": input.hm1_matrix_ratio(),
+
+                # Dendrogram ratios — keep defaults
                 "Rotate_Label_": False,
                 "Horizontal_Dendrogram_Display_Ratio": 0.2,
                 "Vertical_Dendrogram_Display_Ratio": 0.2,
-                "Value_Min": vmin,
-                "Value_Max": vmax,
-                "Color_Map": cmap,
             }
 
             # Call template to get ClusterGrid and dataframe in-memory.

--- a/server/feat_vs_anno_server.py
+++ b/server/feat_vs_anno_server.py
@@ -3,16 +3,20 @@ Feature vs Annotation heatmap visualization module for SPAC Shiny application.
 
 This module handles the server-side logic for generating heatmaps that
 visualize features (genes/proteins) against cell annotations using the
-hierarchical_heatmap function.
+hierarchical_heatmap_template functionality.
 """
 
 from shiny import ui, render, reactive, req
-import anndata as ad
 import numpy as np
-import pandas as pd
 import logging
-import spac.visualization
+from typing import Tuple, Any
+
+from utils.template_wrapper import (
+    register_memory_object,
+    unregister_memory_object,
+)
 from utils.plot_utils import abbreviate_labels, apply_axis_style
+from spac.templates.hierarchical_heatmap_template import run_from_json
 
 
 # Set up logger
@@ -22,6 +26,10 @@ logger = logging.getLogger(__name__)
 def feat_vs_anno_server(input, output, session, shared):
     """
     Server logic for feature vs annotation heatmap visualization.
+
+    This implementation registers the in-memory AnnData object with the
+    memory registry and delegates plotting to
+    `spac.templates.hierarchical_heatmap_template.run_from_json`.
 
     Parameters
     ----------
@@ -35,57 +43,55 @@ def feat_vs_anno_server(input, output, session, shared):
         Shared reactive values across server modules
     """
 
-    def on_layer_check():
+    @reactive.calc
+    def get_adata():
+        """Get the main AnnData object from shared state."""
+        return shared['adata_main'].get()
+
+    @reactive.calc
+    def get_layer():
         """
-        Get the selected layer name or None for original data.
+        Get the selected layer name.
 
         Returns
         -------
-        str or None
-            Layer name if not "Original", otherwise None
+        str
+            Layer name, or 'Original' to use adata.X.
         """
-        return input.hm1_layer() if input.hm1_layer() != "Original" else None
+        return input.hm1_layer() if input.hm1_layer() != "Original" else "Original"
 
-    def on_dendro_check():
+    @reactive.calc
+    def get_dendrogram_settings():
         """
         Check if dendrogram is enabled and return the appropriate values.
 
         Returns
         -------
-        tuple of (bool, bool) or (None, None)
-            Annotation dendrogram and feature dendrogram flags.
-            Returns (None, None) if dendrogram is disabled.
+        tuple of (bool, bool)
+            (cluster_annotations, cluster_features)
         """
-        return (
-            (input.hm1_anno_dendro(), input.hm1_feat_dendro())
-            if input.hm1_dendogram()
-            else (None, None)
-        )
+        if input.hm1_dendogram():
+            return (input.hm1_anno_dendro(), input.hm1_feat_dendro())
+        return (False, False)
 
     @reactive.calc
-    def get_adata():
+    def get_vmin_vmax():
         """
-        Get the main AnnData object from shared state.
+        Process min/max value inputs.
 
         Returns
         -------
-        anndata.AnnData or None
-            AnnData object reconstructed from shared data components
-            Returns None if data is not loaded
+        tuple of (str or float, str or float)
+            (vmin, vmax) values, or "None" if not available
         """
-        x_data = shared['X_data'].get()
-
-        # STOP THE CRASH: If data isn't loaded, don't access .dtype
-        if x_data is None:
-            return None
-
-        return ad.AnnData(
-            X=x_data,
-            obs=pd.DataFrame(shared['obs_data'].get()),
-            var=pd.DataFrame(shared['var_data'].get()),
-            layers=shared['layers_data'].get(),
-            dtype=x_data.dtype
-        )
+        try:
+            vmin = input.hm1_min_select()
+            vmax = input.hm1_max_select()
+        except Exception:
+            vmin = "None"
+            vmax = "None"
+        return (vmin if vmin is not None else "None",
+                vmax if vmax is not None else "None")
 
     @output
     @render.plot(alt="Heatmap Plot")
@@ -111,52 +117,88 @@ def feat_vs_anno_server(input, output, session, shared):
         if adata is None:
             return None
 
-        vmin = input.hm1_min_select()
-        vmax = input.hm1_max_select()
-        kwargs = {"vmin": vmin, "vmax": vmax}
-        cluster_annotations, cluster_features = on_dendro_check()
+        annotation = input.hm1_anno()
+        layer = get_layer()
+        cmap = input.hm1_cmap()
+        cluster_annotations, cluster_features = get_dendrogram_settings()
+        vmin, vmax = get_vmin_vmax()
 
-        # Error Handling: Catch and log specific errors
+        # Register adata in memory registry and call run_from_json
         try:
-            df, fig, ax = spac.visualization.hierarchical_heatmap(
-                adata,
-                annotation=input.hm1_anno(),
-                layer=on_layer_check(),
-                z_score=None,
-                cluster_annotations=cluster_annotations,
-                cluster_feature=cluster_features,
-                **kwargs
+            virtual_path = register_memory_object(adata)
+
+            params = {
+                "Upstream_Analysis": virtual_path,
+                "Annotation": annotation,
+                "Table_to_Visualize": layer,
+                "Feature_s_": ["All"],
+                "Standard_Scale_": "None",
+                "Z_Score": "None",
+                "Feature_Dendrogram": cluster_features,
+                "Annotation_Dendrogram": cluster_annotations,
+                "Figure_Title": "Hierarchical Heatmap",
+                "Figure_Width": 8,
+                "Figure_Height": 8,
+                "Figure_DPI": 300,
+                "Font_Size": 10,
+                "Matrix_Plot_Ratio": 0.8,
+                "Swap_Axes": False,
+                "Rotate_Label_": False,
+                "Horizontal_Dendrogram_Display_Ratio": 0.2,
+                "Vertical_Dendrogram_Display_Ratio": 0.2,
+                "Value_Min": vmin,
+                "Value_Max": vmax,
+                "Color_Map": cmap,
+            }
+
+            # Call template to get ClusterGrid and dataframe in-memory.
+            # Requires the fixed hierarchical_heatmap_template that
+            # returns (clustergrid, mean_intensity) when
+            # save_results_flag=False. See SCSAWorkflow PR #425.
+            result: Tuple[Any, Any] = run_from_json(
+                json_path=params,
+                save_results_flag=False,
+                show_plot=False
             )
+            if result is None:
+                return None
+
+            clustergrid, df = result
+
         except ValueError as e:
-            error_msg = ("Heatmap generation failed with invalid "
-                        f"parameters: {e}")
-            logger.error(error_msg)
+            logger.error(
+                "Heatmap generation failed with invalid parameters: %s", e
+            )
             return None
         except Exception as e:
-            error_msg = ("Unexpected error during heatmap "
-                        f"generation: {e}")
-            logger.error(error_msg)
+            logger.error(
+                "Unexpected error during heatmap generation: %s", e
+            )
             return None
+        finally:
+            try:
+                unregister_memory_object(virtual_path)
+            except Exception:
+                pass
 
-        if fig is None or not hasattr(fig, "ax_heatmap"):
+        if clustergrid is None or not hasattr(clustergrid, "ax_heatmap"):
             logger.error("Invalid figure structure.")
             return None
 
         # Apply colormap
-        cmap = input.hm1_cmap()
         if cmap != "viridis":
-            fig.ax_heatmap.collections[0].set_cmap(cmap)
+            clustergrid.ax_heatmap.collections[0].set_cmap(cmap)
 
         shared['df_heatmap'].set(df)
 
         # Rotate X and Y axis labels
-        fig.ax_heatmap.set_xticklabels(
-            fig.ax_heatmap.get_xticklabels(),
+        clustergrid.ax_heatmap.set_xticklabels(
+            clustergrid.ax_heatmap.get_xticklabels(),
             rotation=input.hm1_x_label_rotation(),
             horizontalalignment='right'
         )
-        fig.ax_heatmap.set_yticklabels(
-            fig.ax_heatmap.get_yticklabels(),
+        clustergrid.ax_heatmap.set_yticklabels(
+            clustergrid.ax_heatmap.get_yticklabels(),
             rotation=input.hm1_y_label_rotation(),
             verticalalignment='center'
         )
@@ -165,25 +207,28 @@ def feat_vs_anno_server(input, output, session, shared):
         if input.hm1_enable_abbreviation():
             limit = input.hm1_label_char_limit()
             abbreviated_xticks = abbreviate_labels(
-                fig.ax_heatmap.get_xticklabels(), limit)
-            fig.ax_heatmap.set_xticklabels(
-                abbreviated_xticks, rotation=input.hm1_x_label_rotation())
+                clustergrid.ax_heatmap.get_xticklabels(), limit)
+            clustergrid.ax_heatmap.set_xticklabels(
+                abbreviated_xticks,
+                rotation=input.hm1_x_label_rotation())
             abbreviated_yticks = abbreviate_labels(
-                fig.ax_heatmap.get_yticklabels(), limit)
-            fig.ax_heatmap.set_yticklabels(
-                abbreviated_yticks, rotation=input.hm1_y_label_rotation())
+                clustergrid.ax_heatmap.get_yticklabels(), limit)
+            clustergrid.ax_heatmap.set_yticklabels(
+                abbreviated_yticks,
+                rotation=input.hm1_y_label_rotation())
 
         # Set font size for axis labels
         axis_fontsize = input.hm1_axis_label_fontsize()
-        apply_axis_style(fig.ax_heatmap.get_xticklabels(), axis_fontsize)
-        apply_axis_style(fig.ax_heatmap.get_yticklabels(), axis_fontsize)
+        apply_axis_style(
+            clustergrid.ax_heatmap.get_xticklabels(), axis_fontsize)
+        apply_axis_style(
+            clustergrid.ax_heatmap.get_yticklabels(), axis_fontsize)
 
         # Adjust figure layout with small margins to prevent label clipping
-        # rect format: [left, bottom, right, top] as fraction of figure size
         LAYOUT_RECT = (0.02, 0.02, 0.98, 0.98)
-        fig.fig.tight_layout(rect=LAYOUT_RECT)
-        fig.fig.subplots_adjust(bottom=0.15, left=0)
-        return fig
+        clustergrid.fig.tight_layout(rect=LAYOUT_RECT)
+        clustergrid.fig.subplots_adjust(bottom=0.15, left=0)
+        return clustergrid
 
     @render.download(filename="heatmap_data.csv")
     def download_df_hm1():
@@ -217,27 +262,22 @@ def feat_vs_anno_server(input, output, session, shared):
             if input.hm1_layer() == "Original":
                 layer_data = adata.X
             else:
-                # Check if layer exists in AnnData
                 if input.hm1_layer() not in adata.layers:
                     return None
                 layer_data = adata.layers[input.hm1_layer()]
 
-            # Check if annotation exists in obs
             if input.hm1_anno() not in adata.obs:
                 return None
 
-            # Filter layer data based on valid annotations
             mask = adata.obs[input.hm1_anno()].notna()
             layer_data = layer_data[mask]
 
-            # Avoid calculation on empty data
             if layer_data.size == 0:
                 return None
 
             min_val = round(float(np.min(layer_data)), 2)
             max_val = round(float(np.max(layer_data)), 2)
 
-            # UI Update
             ui.remove_ui("#inserted-hm1_min_num")
             ui.remove_ui("#inserted-hm1_max_num")
 
@@ -267,5 +307,5 @@ def feat_vs_anno_server(input, output, session, shared):
                 where="beforeEnd",
             )
         except Exception as e:
-            logger.error(f"Error updating min/max values: {e}")
+            logger.error("Error updating min/max values: %s", e)
             return None

--- a/server/nearest_neighbor_server.py
+++ b/server/nearest_neighbor_server.py
@@ -222,7 +222,7 @@ def nearest_neighbor_server(input, output, session, shared):
                 # Call run_from_json with virtual path
                 figs, df_data = run_from_json(
                     json_path=params,
-                    save_results=False,  # Return figures directly
+                    save_to_disk=False,  # Return figures directly
                     show_plot=False
                 )
             finally:

--- a/server/ripleyL_server.py
+++ b/server/ripleyL_server.py
@@ -6,7 +6,7 @@ from utils.template_wrapper import (
     register_memory_object,
     unregister_memory_object,
 )
-from spac.templates.visualize_ripley_template import run_from_json
+from spac.templates.visualize_ripley_l_template import run_from_json
 
 
 def ripleyL_server(input, output, session, shared):
@@ -15,7 +15,7 @@ def ripleyL_server(input, output, session, shared):
 
     This implementation registers the in-memory AnnData object with the
     memory registry and delegates plotting to
-    `spac.templates.visualize_ripley_template.run_from_json`.
+    `spac.templates.visualize_ripley_l_template.run_from_json`.
 
     Parameters
     ----------

--- a/server/ripleyL_server.py
+++ b/server/ripleyL_server.py
@@ -81,7 +81,7 @@ def ripleyL_server(input, output, session, shared):
 
             # Call template to get figure and dataframe in-memory
             figs_df: Tuple[Any, Any] = run_from_json(
-                json_path=params, save_results=False, show_plot=False
+                json_path=params, save_to_disk=False, show_plot=False
             )
             if figs_df is None:
                 return None

--- a/ui/feat_vs_anno_ui.py
+++ b/ui/feat_vs_anno_ui.py
@@ -79,6 +79,8 @@ def feat_vs_anno_ui():
                                 "Select a Table",
                                 choices=[]
                             ),
+                            # Dynamic feature selector (populated by server)
+                            ui.output_ui("hm1_features_ui"),
 
                             ui.hr(),
 
@@ -98,10 +100,31 @@ def feat_vs_anno_ui():
                                             "viridis", "plasma", "inferno",
                                             "magma", "cividis", "coolwarm",
                                             "RdYlBu", "Spectral", "PiYG",
-                                            "PRGn"
+                                            "PRGn", "seismic"
                                         ],
                                         selected="viridis"
-                                    ),  # Dropdown for color maps
+                                    ),
+                                    ui.input_select(
+                                        "hm1_z_score",
+                                        "Z Score",
+                                        choices=[
+                                            "None", "feature", "annotation"
+                                        ],
+                                        selected="None"
+                                    ),
+                                    ui.input_select(
+                                        "hm1_standard_scale",
+                                        "Standard Scale",
+                                        choices=[
+                                            "None", "0", "1"
+                                        ],
+                                        selected="None"
+                                    ),
+                                    ui.input_checkbox(
+                                        "hm1_swap_axes",
+                                        "Swap Axes",
+                                        value=False
+                                    ),
                                     ui.input_checkbox(
                                         "hm1_dendogram",
                                         "Include Dendrogram",
@@ -122,6 +145,61 @@ def feat_vs_anno_ui():
                                     ),
                                     ui.div(id="main-hm1_min_num"),
                                     ui.div(id="main-hm1_max_num"),
+                                ),
+                            ),
+
+                            ui.hr(),
+
+                            # Figure configuration in expandable section
+                            ui.div(
+                                ui.input_checkbox(
+                                    "hm1_show_figure_config",
+                                    "Show Figure Configuration",
+                                    value=False
+                                ),
+                                ui.panel_conditional(
+                                    "input.hm1_show_figure_config",
+                                    ui.input_text(
+                                        "hm1_figure_title",
+                                        "Figure Title",
+                                        value="Hierarchical Heatmap"
+                                    ),
+                                    ui.input_numeric(
+                                        "hm1_figure_width",
+                                        "Figure Width",
+                                        min=4,
+                                        max=30,
+                                        value=15
+                                    ),
+                                    ui.input_numeric(
+                                        "hm1_figure_height",
+                                        "Figure Height",
+                                        min=4,
+                                        max=30,
+                                        value=12
+                                    ),
+                                    ui.input_numeric(
+                                        "hm1_figure_dpi",
+                                        "Figure DPI",
+                                        min=72,
+                                        max=600,
+                                        value=300
+                                    ),
+                                    ui.input_numeric(
+                                        "hm1_font_size",
+                                        "Font Size",
+                                        min=4,
+                                        max=24,
+                                        value=14
+                                    ),
+                                    ui.input_numeric(
+                                        "hm1_matrix_ratio",
+                                        "Matrix Plot Ratio",
+                                        min=0.1,
+                                        max=1.0,
+                                        value=0.8,
+                                        step=0.1
+                                    ),
                                 ),
                             ),
 
@@ -196,7 +274,6 @@ def feat_vs_anno_ui():
                                     "height: 85vh; overflow: auto; "
                                     "padding-left: 15px;"
                                 ),
-                                # "style": "padding-bottom: 100px;"
                             },
                             ui.output_plot(
                                 "spac_Heatmap",

--- a/ui/feat_vs_anno_ui.py
+++ b/ui/feat_vs_anno_ui.py
@@ -102,7 +102,7 @@ def feat_vs_anno_ui():
                                             "RdYlBu", "Spectral", "PiYG",
                                             "PRGn", "seismic"
                                         ],
-                                        selected="viridis"
+                                        selected="seismic"
                                     ),
                                     ui.input_select(
                                         "hm1_z_score",
@@ -128,19 +128,19 @@ def feat_vs_anno_ui():
                                     ui.input_checkbox(
                                         "hm1_dendogram",
                                         "Include Dendrogram",
-                                        False
+                                        True
                                     ),
                                     ui.panel_conditional(
                                         "input.hm1_dendogram",
                                         ui.input_checkbox(
                                             "hm1_feat_dendro",
                                             "Feature Cluster",
-                                            value=False
+                                            value=True
                                         ),
                                         ui.input_checkbox(
                                             "hm1_anno_dendro",
                                             "Annotation Cluster",
-                                            value=False
+                                            value=True
                                         ),
                                     ),
                                     ui.div(id="main-hm1_min_num"),


### PR DESCRIPTION
- Delegate heatmap rendering to hierarchical_heatmap_template's run_from_json via memory registry, matching nearest_neighbor_server and ripleyL_server architecture.
- Update spac pin to SCSAWorkflow commit 598517d which fixes the template to return (clustergrid, df) when save_results_flag=False.
- Preserves all existing UI features: colormap, dendrogram toggles, axis rotation, label abbreviation, min/max range updates.

Depends on: SCSAWorkflow PR #425