### PR TITLE
UMAP Refactoring

### DIFF
--- a/server/effect_update_server.py
+++ b/server/effect_update_server.py
@@ -8,9 +8,56 @@ from shiny import ui, render, reactive
 from utils.data_processing import get_annotation_label_counts
 import anndata as ad
 import spac.data_utils
+import numpy as np
 
 
 def effect_update_server(input, output, session, shared):
+    def _extract_feature_values(adata, feature_name, layer_name):
+        """Return 1D numeric values for a selected feature from X/layer."""
+        if adata is None or feature_name is None:
+            return None
+        if feature_name not in adata.var_names:
+            return None
+
+        source = adata.X if layer_name == "Original" else adata.layers.get(layer_name)
+        if source is None:
+            return None
+
+        try:
+            col_idx = int(adata.var_names.get_loc(feature_name))
+            values = source[:, col_idx]
+            if hasattr(values, "toarray"):
+                values = values.toarray().ravel()
+            else:
+                values = np.asarray(values).ravel()
+            return values
+        except Exception:
+            return None
+
+    def _update_umap_value_range_inputs(val_min_id, val_max_id, values):
+        """Update min/max numeric inputs using finite data bounds."""
+        if values is None:
+            return
+        finite = values[np.isfinite(values)]
+        if finite.size == 0:
+            return
+
+        min_val = round(float(np.min(finite)), 4)
+        max_val = round(float(np.max(finite)), 4)
+
+        ui.update_numeric(
+            val_min_id,
+            value=min_val,
+            min=min_val,
+            max=max_val,
+        )
+        ui.update_numeric(
+            val_max_id,
+            value=max_val,
+            min=min_val,
+            max=max_val,
+        )
+
     @reactive.Effect
     def update_select_input_feat():
         choices = shared['var_names'].get()
@@ -85,6 +132,30 @@ def effect_update_server(input, output, session, shared):
             ui.update_select("hm1_layer", choices=new_choices)
             ui.update_select("scatter_layer", choices=new_choices)
         return
+
+    @reactive.Effect
+    def update_umap_min_max_panel1():
+        adata = shared['adata_main'].get()
+        mode = input.umap_rb()
+        feature = input.umap_rb_feat()
+        layer = input.umap_layer()
+        if mode != "Feature" or feature is None or layer is None:
+            return
+
+        values = _extract_feature_values(adata, feature, layer)
+        _update_umap_value_range_inputs("umap_val_min", "umap_val_max", values)
+
+    @reactive.Effect
+    def update_umap_min_max_panel2():
+        adata = shared['adata_main'].get()
+        mode = input.umap_rb2()
+        feature = input.umap_rb_feat2()
+        layer = input.umap_layer2()
+        if mode != "Feature" or feature is None or layer is None:
+            return
+
+        values = _extract_feature_values(adata, feature, layer)
+        _update_umap_value_range_inputs("umap_val_min2", "umap_val_max2", values)
 
     @reactive.Effect
     def update_rl_pairs():

--- a/server/umap_server.py
+++ b/server/umap_server.py
@@ -22,6 +22,26 @@ def _prevent_label_clipping(fig):
         pass
 
 
+def _set_feature_colorbar_fontsize(fig, fontsize):
+    """Apply feature-mode legend font size to matplotlib colorbar ticks."""
+    if fig is None:
+        return
+    try:
+        size = float(fontsize)
+    except Exception:
+        return
+    for ax in getattr(fig, "axes", []):
+        # Colorbar axes are typically very narrow (vertical bar) or short (horizontal bar).
+        bbox = ax.get_position()
+        is_colorbar_axis = (bbox.width < 0.08) or (bbox.height < 0.08)
+        if not is_colorbar_axis:
+            continue
+        try:
+            ax.tick_params(axis="both", labelsize=size)
+        except Exception:
+            continue
+
+
 def umap_server(input, output, session, shared):
     @reactive.calc
     def get_adata():
@@ -143,6 +163,8 @@ def umap_server(input, output, session, shared):
             )
             if fig is None:
                 return None
+            if mode == "Feature":
+                _set_feature_colorbar_fontsize(fig, fl["Legend_Font_Size"])
             _prevent_label_clipping(fig)
             return fig
         except Exception:

--- a/server/umap_server.py
+++ b/server/umap_server.py
@@ -7,23 +7,38 @@ from utils.template_wrapper import (
 from spac.templates.umap_tsne_pca_template import run_from_json
 
 
+def _prevent_label_clipping(fig):
+    """Add safe margins so axis labels are fully visible."""
+    if fig is None:
+        return
+    try:
+        fig.tight_layout(pad=1.4)
+    except Exception:
+        pass
+    try:
+        # Keep a small outer frame in case tight_layout is insufficient.
+        fig.subplots_adjust(left=0.12, right=0.98, bottom=0.12, top=0.94)
+    except Exception:
+        pass
+
+
 def umap_server(input, output, session, shared):
     @reactive.calc
     def get_adata():
         return shared["adata_main"].get()
 
     def _figure_legend_params(panel: int):
-        """panel 1 or 2. Template defaults match spac umap_tsne_pca_template."""
+        """panel 1 or 2. Use pre-template method-like display defaults when collapsed."""
         if panel == 1:
             if not input.umap_show_figure_config():
                 return {
-                    "Figure_Width": 12,
-                    "Figure_Height": 12,
-                    "Figure_DPI": 300,
-                    "Font_Size": 12,
-                    "Legend_Location": "best",
-                    "Legend_Font_Size": 16,
-                    "Legend_Marker_Size": 5.0,
+                    "Figure_Width": 10,
+                    "Figure_Height": 8,
+                    "Figure_DPI": 110,
+                    "Font_Size": 8,
+                    "Legend_Location": "upper right",
+                    "Legend_Font_Size": 8,
+                    "Legend_Marker_Size": 1.5,
                 }
             return {
                 "Figure_Width": input.umap_fig_width(),
@@ -36,13 +51,13 @@ def umap_server(input, output, session, shared):
             }
         if not input.umap_show_figure_config2():
             return {
-                "Figure_Width": 12,
-                "Figure_Height": 12,
-                "Figure_DPI": 300,
-                "Font_Size": 12,
-                "Legend_Location": "best",
-                "Legend_Font_Size": 16,
-                "Legend_Marker_Size": 5.0,
+                "Figure_Width": 10,
+                "Figure_Height": 8,
+                "Figure_DPI": 110,
+                "Font_Size": 8,
+                "Legend_Location": "upper right",
+                "Legend_Font_Size": 8,
+                "Legend_Marker_Size": 1.5,
             }
         return {
             "Figure_Width": input.umap_fig_width2(),
@@ -128,6 +143,7 @@ def umap_server(input, output, session, shared):
             )
             if fig is None:
                 return None
+            _prevent_label_clipping(fig)
             return fig
         except Exception:
             import traceback

--- a/server/umap_server.py
+++ b/server/umap_server.py
@@ -1,85 +1,176 @@
-from shiny import ui, render, reactive
-import anndata as ad
-import pandas as pd
-import spac.visualization
+from shiny import ui, render, reactive, req
+
+from utils.template_wrapper import (
+    register_memory_object,
+    unregister_memory_object,
+)
+from spac.templates.umap_tsne_pca_template import run_from_json
 
 
 def umap_server(input, output, session, shared):
+    @reactive.calc
+    def get_adata():
+        return shared["adata_main"].get()
+
+    def _figure_legend_params(panel: int):
+        """panel 1 or 2. Template defaults match spac umap_tsne_pca_template."""
+        if panel == 1:
+            if not input.umap_show_figure_config():
+                return {
+                    "Figure_Width": 12,
+                    "Figure_Height": 12,
+                    "Figure_DPI": 300,
+                    "Font_Size": 12,
+                    "Legend_Location": "best",
+                    "Legend_Font_Size": 16,
+                    "Legend_Marker_Size": 5.0,
+                }
+            return {
+                "Figure_Width": input.umap_fig_width(),
+                "Figure_Height": input.umap_fig_height(),
+                "Figure_DPI": input.umap_fig_dpi(),
+                "Font_Size": input.umap_font_size(),
+                "Legend_Location": input.umap_legend_location(),
+                "Legend_Font_Size": input.umap_legend_font_size(),
+                "Legend_Marker_Size": input.umap_legend_marker_scale(),
+            }
+        if not input.umap_show_figure_config2():
+            return {
+                "Figure_Width": 12,
+                "Figure_Height": 12,
+                "Figure_DPI": 300,
+                "Font_Size": 12,
+                "Legend_Location": "best",
+                "Legend_Font_Size": 16,
+                "Legend_Marker_Size": 5.0,
+            }
+        return {
+            "Figure_Width": input.umap_fig_width2(),
+            "Figure_Height": input.umap_fig_height2(),
+            "Figure_DPI": input.umap_fig_dpi2(),
+            "Font_Size": input.umap_font_size2(),
+            "Legend_Location": input.umap_legend_location2(),
+            "Legend_Font_Size": input.umap_legend_font_size2(),
+            "Legend_Marker_Size": input.umap_legend_marker_scale2(),
+        }
+
+    def _value_range_params(panel: int, mode: str):
+        if mode != "Feature":
+            return "None", "None"
+        if panel == 1:
+            if not input.umap_use_val_range():
+                return "None", "None"
+            return str(input.umap_val_min()), str(input.umap_val_max())
+        if not input.umap_use_val_range2():
+            return "None", "None"
+        return str(input.umap_val_min2()), str(input.umap_val_max2())
+
+    def _run_umap_plot(*, plottype_id: str, rb_id: str, slider_id: str, panel: int):
+        adata = get_adata()
+        if adata is None:
+            return None
+
+        method = getattr(input, plottype_id)()
+        point_size = getattr(input, slider_id)()
+        mode = getattr(input, rb_id)()
+
+        if mode == "Feature":
+            if panel == 1:
+                req(input.umap_rb_feat())
+                feature = input.umap_rb_feat()
+                layer_raw = input.umap_layer()
+            else:
+                req(input.umap_rb_feat2())
+                feature = input.umap_rb_feat2()
+                layer_raw = input.umap_layer2()
+            layer_str = "Original" if layer_raw == "Original" else layer_raw
+            color_by = "Feature"
+            annotation_hl = "None"
+            feature_hl = feature
+        elif mode == "Annotation":
+            if panel == 1:
+                req(input.umap_rb_anno())
+                annotation = input.umap_rb_anno()
+            else:
+                req(input.umap_rb_anno2())
+                annotation = input.umap_rb_anno2()
+            color_by = "Annotation"
+            annotation_hl = annotation
+            feature_hl = "None"
+            layer_str = "Original"
+        else:
+            return None
+
+        fl = _figure_legend_params(panel)
+        v_min, v_max = _value_range_params(panel, mode)
+
+        params = {
+            "Upstream_Analysis": None,
+            "Color_By": color_by,
+            "Annotation_to_Highlight": annotation_hl,
+            "Feature_to_Highlight": feature_hl,
+            "Table": layer_str,
+            "Dimension_Reduction_Method": method,
+            "Dot_Size": point_size,
+            "Value_Min": v_min,
+            "Value_Max": v_max,
+            **fl,
+        }
+
+        virtual_path = None
+        try:
+            virtual_path = register_memory_object(adata)
+            params["Upstream_Analysis"] = virtual_path
+            fig, _df = run_from_json(
+                json_path=params,
+                save_results=False,
+                show_plot=False,
+            )
+            if fig is None:
+                return None
+            return fig
+        except Exception:
+            import traceback
+
+            traceback.print_exc()
+            return None
+        finally:
+            if virtual_path:
+                unregister_memory_object(virtual_path)
+
     @output
     @render.plot
     @reactive.event(input.go_umap1, ignore_none=True)
     def spac_UMAP():
-        adata = ad.AnnData(
-            X=shared['X_data'].get(),
-            var=pd.DataFrame(shared['var_data'].get()),
-            obsm=shared['obsm_data'].get(),
-            obs=shared['obs_data'].get(),
-            dtype=shared['X_data'].get().dtype,
-            layers=shared['layers_data'].get()
+        return _run_umap_plot(
+            plottype_id="plottype",
+            rb_id="umap_rb",
+            slider_id="umap_slider_1",
+            panel=1,
         )
 
-        if adata is None:
-            return None
-
-        method = input.plottype()
-        point_size = input.umap_slider_1()
-        mode = input.umap_rb()
-
-        if mode == "Feature":
-            feature = input.umap_rb_feat()
-            layer = None if input.umap_layer() == "Original" else input.umap_layer()
-            fig, ax = spac.visualization.dimensionality_reduction_plot(
-                adata, method=method, feature=feature, layer=layer, point_size=point_size
-            )
-            ax.set_title(f"{method.upper()}: {feature}", fontsize=14)
-            ax.set_xlabel(f"{method.upper()} 1")
-            ax.set_ylabel(f"{method.upper()} 2")
-
-            for extra_ax in fig.axes:
-                if hasattr(extra_ax, "get_ylabel") and extra_ax != ax:
-                    extra_ax.set_ylabel(f"Colored by: {feature.upper()}", fontsize=12)
-
-            return fig
-
-        elif mode == "Annotation":
-            annotation = input.umap_rb_anno()
-            fig, ax = spac.visualization.dimensionality_reduction_plot(
-                adata, method=method, annotation=annotation, point_size=point_size
-            )
-            ax.set_title(f"{method.upper()}: {annotation}", fontsize=14)
-            ax.set_xlabel(f"{method.upper()} 1")
-            ax.set_ylabel(f"{method.upper()} 2")
-
-            return fig
-
-        return None
-
-    # Track the UI state
     umap_annotation_initialized = reactive.Value(False)
     umap_feature_initialized = reactive.Value(False)
 
     @reactive.effect
     def umap_reactivity():
-        flipper = shared['data_loaded'].get()
+        flipper = shared["data_loaded"].get()
         if flipper is not False:
             btn = input.umap_rb()
 
             if btn == "Annotation":
                 if not umap_annotation_initialized.get():
-                    # Create the Annotation dropdown
                     dropdown = ui.input_select(
-                        "umap_rb_anno", 
-                        "Select an Annotation", 
-                        choices=shared['obs_names'].get(),
+                        "umap_rb_anno",
+                        "Select an Annotation",
+                        choices=shared["obs_names"].get(),
                     )
                     ui.insert_ui(
                         ui.div({"id": "inserted-rbdropdown_anno"}, dropdown),
                         selector="#main-ump_rb_dropdown_anno",
                         where="beforeEnd",
                     )
-                    # Update the state
                     umap_annotation_initialized.set(True)
-                # Remove the Feature dropdown and table
                 if umap_feature_initialized.get():
                     ui.remove_ui("#inserted-rbdropdown_feat")
                     ui.remove_ui("#inserted-umap_table")
@@ -87,11 +178,10 @@ def umap_server(input, output, session, shared):
 
             elif btn == "Feature":
                 if not umap_feature_initialized.get():
-                    # Create the Feature dropdown
                     dropdown1 = ui.input_select(
-                        "umap_rb_feat", 
-                        "Select a Feature", 
-                        choices=shared['var_names'].get()
+                        "umap_rb_feat",
+                        "Select a Feature",
+                        choices=shared["var_names"].get(),
                     )
                     ui.insert_ui(
                         ui.div({"id": "inserted-rbdropdown_feat"}, dropdown1),
@@ -99,28 +189,24 @@ def umap_server(input, output, session, shared):
                         where="beforeEnd",
                     )
 
-                    # Create the Table dropdown
-                    new_choices = shared['layers_names'].get() + ["Original"]
+                    new_choices = shared["layers_names"].get() + ["Original"]
                     table_umap = ui.input_select(
-                        "umap_layer", 
-                        "Select a Table", 
-                        choices=new_choices, 
-                        selected=["Original"]
+                        "umap_layer",
+                        "Select a Table",
+                        choices=new_choices,
+                        selected=["Original"],
                     )
                     ui.insert_ui(
                         ui.div({"id": "inserted-umap_table"}, table_umap),
                         selector="#main-ump_table_dropdown_feat",
                         where="beforeEnd",
                     )
-                    # Update the state
                     umap_feature_initialized.set(True)
-                # Remove the Annotation dropdown
                 if umap_annotation_initialized.get():
                     ui.remove_ui("#inserted-rbdropdown_anno")
                     umap_annotation_initialized.set(False)
 
             elif btn == "None":
-                # Remove all dropdowns and reset states
                 if umap_annotation_initialized.get():
                     ui.remove_ui("#inserted-rbdropdown_anno")
                     umap_annotation_initialized.set(False)
@@ -129,72 +215,32 @@ def umap_server(input, output, session, shared):
                     ui.remove_ui("#inserted-umap_table")
                     umap_feature_initialized.set(False)
 
-
     @output
     @render.plot
     @reactive.event(input.go_umap2, ignore_none=True)
     def spac_UMAP2():
-        adata = ad.AnnData(
-            X=shared['X_data'].get(),
-            var=pd.DataFrame(shared['var_data'].get()),
-            obsm=shared['obsm_data'].get(),
-            obs=shared['obs_data'].get(),
-            dtype=shared['X_data'].get().dtype,
-            layers=shared['layers_data'].get()
+        return _run_umap_plot(
+            plottype_id="plottype2",
+            rb_id="umap_rb2",
+            slider_id="umap_slider_2",
+            panel=2,
         )
 
-        if adata is None:
-            return None
-
-        method = input.plottype2()
-        point_size = input.umap_slider_2()
-        mode = input.umap_rb2()
-
-        if mode == "Feature":
-            feature = input.umap_rb_feat2()
-            layer = None if input.umap_layer2() == "Original" else input.umap_layer2()
-            fig, ax = spac.visualization.dimensionality_reduction_plot(
-                adata, method=method, feature=feature, layer=layer, point_size=point_size
-            )
-            ax.set_title(f"{method.upper()}: {feature}", fontsize=14)
-            ax.set_xlabel(f"{method.upper()} 1")
-            ax.set_ylabel(f"{method.upper()} 2")
-
-            for extra_ax in fig.axes:
-                if hasattr(extra_ax, "get_ylabel") and extra_ax != ax:
-                    extra_ax.set_ylabel(f"Colored by: {feature}", fontsize=12)
-
-            return fig
-
-        elif mode == "Annotation":
-            annotation = input.umap_rb_anno2()
-            fig, ax = spac.visualization.dimensionality_reduction_plot(
-                adata, method=method, annotation=annotation, point_size=point_size
-            )
-            ax.set_title(f"{method.upper()}: {annotation}", fontsize=14)
-            ax.set_xlabel(f"{method.upper()} 1")
-            ax.set_ylabel(f"{method.upper()} 2")
-
-            return fig
-
-        return None
-
-    # Track the UI state
     umap2_annotation_initialized = reactive.Value(False)
     umap2_feature_initialized = reactive.Value(False)
 
     @reactive.effect
     def umap_reactivity2():
-        flipper = shared['data_loaded'].get()
+        flipper = shared["data_loaded"].get()
         if flipper is not False:
             btn = input.umap_rb2()
 
             if btn == "Annotation":
                 if not umap2_annotation_initialized.get():
                     dropdown = ui.input_select(
-                        "umap_rb_anno2", 
-                        "Select an Annotation", 
-                        choices=shared['obs_names'].get()
+                        "umap_rb_anno2",
+                        "Select an Annotation",
+                        choices=shared["obs_names"].get(),
                     )
                     ui.insert_ui(
                         ui.div({"id": "inserted-rbdropdown_anno2"}, dropdown),
@@ -210,9 +256,9 @@ def umap_server(input, output, session, shared):
             elif btn == "Feature":
                 if not umap2_feature_initialized.get():
                     dropdown1 = ui.input_select(
-                        "umap_rb_feat2", 
-                        "Select a Feature", 
-                        choices=shared['var_names'].get()
+                        "umap_rb_feat2",
+                        "Select a Feature",
+                        choices=shared["var_names"].get(),
                     )
                     ui.insert_ui(
                         ui.div({"id": "inserted-rbdropdown_feat2"}, dropdown1),
@@ -220,9 +266,12 @@ def umap_server(input, output, session, shared):
                         where="beforeEnd",
                     )
 
-                    new_choices = shared['layers_names'].get() + ["Original"]
+                    new_choices = shared["layers_names"].get() + ["Original"]
                     table_umap_1 = ui.input_select(
-                        "umap_layer2", "Select a Table", choices=new_choices, selected=["Original"]
+                        "umap_layer2",
+                        "Select a Table",
+                        choices=new_choices,
+                        selected=["Original"],
                     )
                     ui.insert_ui(
                         ui.div({"id": "inserted-umap_table2"}, table_umap_1),

--- a/server/umap_server.py
+++ b/server/umap_server.py
@@ -45,7 +45,7 @@ def umap_server(input, output, session, shared):
                 "Figure_Height": input.umap_fig_height(),
                 "Figure_DPI": input.umap_fig_dpi(),
                 "Font_Size": input.umap_font_size(),
-                "Legend_Location": input.umap_legend_location(),
+                "Legend_Location": "upper right",
                 "Legend_Font_Size": input.umap_legend_font_size(),
                 "Legend_Marker_Size": input.umap_legend_marker_scale(),
             }
@@ -64,7 +64,7 @@ def umap_server(input, output, session, shared):
             "Figure_Height": input.umap_fig_height2(),
             "Figure_DPI": input.umap_fig_dpi2(),
             "Font_Size": input.umap_font_size2(),
-            "Legend_Location": input.umap_legend_location2(),
+            "Legend_Location": "upper right",
             "Legend_Font_Size": input.umap_legend_font_size2(),
             "Legend_Marker_Size": input.umap_legend_marker_scale2(),
         }

--- a/ui/umap_ui.py
+++ b/ui/umap_ui.py
@@ -62,28 +62,6 @@ def _figure_legend_panel(suffix: str):
             ),
             ui.row(
                 ui.column(
-                    12,
-                    ui.input_select(
-                        f"umap_legend_location{suffix}",
-                        "Legend location",
-                        choices=[
-                            "best",
-                            "upper right",
-                            "upper left",
-                            "lower left",
-                            "lower right",
-                            "center left",
-                            "center right",
-                            "lower center",
-                            "upper center",
-                            "center",
-                        ],
-                        selected="upper right",
-                    ),
-                ),
-            ),
-            ui.row(
-                ui.column(
                     6,
                     ui.input_numeric(
                         f"umap_legend_font_size{suffix}",

--- a/ui/umap_ui.py
+++ b/ui/umap_ui.py
@@ -8,6 +8,7 @@ def _figure_legend_panel(suffix: str):
     """
     show_id = f"umap_show_figure_config{suffix}"
     cond = f"input.{show_id}"
+    mode_is_annotation = f"input.umap_rb{suffix} == 'Annotation'"
     return ui.div(
         ui.input_checkbox(
             show_id,
@@ -47,6 +48,7 @@ def _figure_legend_panel(suffix: str):
                         value=110,
                         min=72,
                         max=600,
+                        step=20,
                     ),
                 ),
                 ui.column(
@@ -73,13 +75,16 @@ def _figure_legend_panel(suffix: str):
                 ),
                 ui.column(
                     6,
-                    ui.input_numeric(
-                        f"umap_legend_marker_scale{suffix}",
-                        "Legend marker scale",
-                        value=1.5,
-                        min=0.5,
-                        max=20,
-                        step=0.5,
+                    ui.panel_conditional(
+                        mode_is_annotation,
+                        ui.input_numeric(
+                            f"umap_legend_marker_scale{suffix}",
+                            "Legend marker scale",
+                            value=1.5,
+                            min=0.5,
+                            max=20,
+                            step=0.5,
+                        ),
                     ),
                 ),
             ),
@@ -89,29 +94,33 @@ def _figure_legend_panel(suffix: str):
 
 def _feature_value_range_panel(suffix: str):
     """Min/max for feature coloring; inputs always present for stable server reads."""
-    return ui.div(
-        ui.input_checkbox(
-            f"umap_use_val_range{suffix}",
-            "Set feature color min/max (Feature mode only)",
-            value=False,
-        ),
-        ui.panel_conditional(
-            f"input.umap_use_val_range{suffix}",
-            ui.row(
-                ui.column(
-                    6,
-                    ui.input_numeric(
-                        f"umap_val_min{suffix}",
-                        "Value min",
-                        value=0.0,
+    mode_is_feature = f"input.umap_rb{suffix} == 'Feature'"
+    return ui.panel_conditional(
+        mode_is_feature,
+        ui.div(
+            ui.input_checkbox(
+                f"umap_use_val_range{suffix}",
+                "Set feature color min/max",
+                value=False,
+            ),
+            ui.panel_conditional(
+                f"input.umap_use_val_range{suffix}",
+                ui.row(
+                    ui.column(
+                        6,
+                        ui.input_numeric(
+                            f"umap_val_min{suffix}",
+                            "Value min",
+                            value=0.0,
+                        ),
                     ),
-                ),
-                ui.column(
-                    6,
-                    ui.input_numeric(
-                        f"umap_val_max{suffix}",
-                        "Value max",
-                        value=1.0,
+                    ui.column(
+                        6,
+                        ui.input_numeric(
+                            f"umap_val_max{suffix}",
+                            "Value max",
+                            value=1.0,
+                        ),
                     ),
                 ),
             ),
@@ -145,10 +154,10 @@ def umap_ui():
                         accessible_slider(
                             "umap_slider_1",
                             "Point Size",
-                            min_val=0.5,
+                            min_val=1,
                             max_val=10,
                             value=3,
-                            step=0.1,
+                            step=1,
                         ),
                         _feature_value_range_panel(""),
                         _figure_legend_panel(""),
@@ -181,10 +190,10 @@ def umap_ui():
                         accessible_slider(
                             "umap_slider_2",
                             "Point Size",
-                            min_val=0.5,
+                            min_val=1,
                             max_val=10,
                             value=3,
-                            step=0.1,
+                            step=1,
                         ),
                         _feature_value_range_panel("2"),
                         _figure_legend_panel("2"),

--- a/ui/umap_ui.py
+++ b/ui/umap_ui.py
@@ -2,24 +2,159 @@ from shiny import ui
 from utils.accessibility import accessible_slider
 
 
+def _figure_legend_panel(suffix: str):
+    """
+    Collapsible figure and legend controls. suffix '' for column 1, '2' for column 2.
+    """
+    show_id = f"umap_show_figure_config{suffix}"
+    cond = f"input.{show_id}"
+    return ui.div(
+        ui.input_checkbox(
+            show_id,
+            "Show figure & legend settings",
+            value=False,
+        ),
+        ui.panel_conditional(
+            cond,
+            ui.row(
+                ui.column(
+                    6,
+                    ui.input_numeric(
+                        f"umap_fig_width{suffix}",
+                        "Figure width",
+                        value=12,
+                        min=4,
+                        max=30,
+                    ),
+                ),
+                ui.column(
+                    6,
+                    ui.input_numeric(
+                        f"umap_fig_height{suffix}",
+                        "Figure height",
+                        value=12,
+                        min=4,
+                        max=30,
+                    ),
+                ),
+            ),
+            ui.row(
+                ui.column(
+                    6,
+                    ui.input_numeric(
+                        f"umap_fig_dpi{suffix}",
+                        "DPI",
+                        value=300,
+                        min=72,
+                        max=600,
+                    ),
+                ),
+                ui.column(
+                    6,
+                    ui.input_numeric(
+                        f"umap_font_size{suffix}",
+                        "Font size",
+                        value=12,
+                        min=6,
+                        max=24,
+                    ),
+                ),
+            ),
+            ui.input_select(
+                f"umap_legend_location{suffix}",
+                "Legend location",
+                choices=[
+                    "best",
+                    "upper right",
+                    "upper left",
+                    "lower left",
+                    "lower right",
+                    "center left",
+                    "center right",
+                    "lower center",
+                    "upper center",
+                    "center",
+                ],
+                selected="best",
+            ),
+            ui.row(
+                ui.column(
+                    6,
+                    ui.input_numeric(
+                        f"umap_legend_font_size{suffix}",
+                        "Legend font size",
+                        value=16,
+                        min=6,
+                        max=32,
+                    ),
+                ),
+                ui.column(
+                    6,
+                    ui.input_numeric(
+                        f"umap_legend_marker_scale{suffix}",
+                        "Legend marker scale",
+                        value=5.0,
+                        min=0.5,
+                        max=20,
+                        step=0.5,
+                    ),
+                ),
+            ),
+        ),
+    )
+
+
+def _feature_value_range_panel(suffix: str):
+    """Min/max for feature coloring; inputs always present for stable server reads."""
+    return ui.div(
+        ui.input_checkbox(
+            f"umap_use_val_range{suffix}",
+            "Set feature color min/max (Feature mode only)",
+            value=False,
+        ),
+        ui.panel_conditional(
+            f"input.umap_use_val_range{suffix}",
+            ui.row(
+                ui.column(
+                    6,
+                    ui.input_numeric(
+                        f"umap_val_min{suffix}",
+                        "Value min",
+                        value=0.0,
+                    ),
+                ),
+                ui.column(
+                    6,
+                    ui.input_numeric(
+                        f"umap_val_max{suffix}",
+                        "Value max",
+                        value=1.0,
+                    ),
+                ),
+            ),
+        ),
+    )
+
+
 def umap_ui():
-    # 8. UMAP PANEL ------------------------------------------
-    return ui.nav_panel("UMAP",
-        ui.card({"style": "width:100%;"},
+    return ui.nav_panel(
+        "UMAP",
+        ui.card(
+            {"style": "width:100%;"},
             ui.column(
                 12,
                 ui.row(
                     ui.column(
                         6,
                         ui.input_radio_buttons(
-                            "umap_rb", 
-                            "Choose one:", 
-                            ["Annotation", "Feature"]
+                            "umap_rb",
+                            "Choose one:",
+                            ["Annotation", "Feature"],
                         ),
                         ui.input_select(
-                            "plottype", 
-                            "Select a plot type", 
-                            choices=["umap", "pca", "tsne"]
+                            "plottype",
+                            "Select a plot type",
+                            choices=["umap", "pca", "tsne"],
                         ),
                         ui.div(id="main-ump_rb_dropdown_anno"),
                         ui.div(id="main-ump_rb_dropdown_feat"),
@@ -30,30 +165,32 @@ def umap_ui():
                             min_val=0.5,
                             max_val=10,
                             value=3,
-                            step=0.1
+                            step=0.1,
                         ),
+                        _feature_value_range_panel(""),
+                        _figure_legend_panel(""),
                         ui.input_action_button(
-                            "go_umap1", 
-                            "Render Plot", 
-                            class_="btn-success"
+                            "go_umap1",
+                            "Render Plot",
+                            class_="btn-success",
                         ),
                         ui.output_plot(
-                            "spac_UMAP", 
-                            width="100%", 
-                            height="80vh"
-                        )
+                            "spac_UMAP",
+                            width="100%",
+                            height="80vh",
+                        ),
                     ),
                     ui.column(
                         6,
                         ui.input_radio_buttons(
-                            "umap_rb2", 
-                            "Choose one:", 
-                            ["Annotation", "Feature"]
+                            "umap_rb2",
+                            "Choose one:",
+                            ["Annotation", "Feature"],
                         ),
                         ui.input_select(
-                            "plottype2", 
-                            "Select a plot type", 
-                            choices=["umap", "pca", "tsne"]
+                            "plottype2",
+                            "Select a plot type",
+                            choices=["umap", "pca", "tsne"],
                         ),
                         ui.div(id="main-ump_rb_dropdown_anno2"),
                         ui.div(id="main-ump_rb_dropdown_feat2"),
@@ -64,21 +201,22 @@ def umap_ui():
                             min_val=0.5,
                             max_val=10,
                             value=3,
-                            step=0.1
+                            step=0.1,
                         ),
+                        _feature_value_range_panel("2"),
+                        _figure_legend_panel("2"),
                         ui.input_action_button(
-                            "go_umap2", 
-                            "Render Plot", 
-                            class_="btn-success"
+                            "go_umap2",
+                            "Render Plot",
+                            class_="btn-success",
                         ),
                         ui.output_plot(
-                            "spac_UMAP2", 
-                            width="100%", 
-                            height="80vh"
-                        )
-                    )
-                )
-            )
-        )
+                            "spac_UMAP2",
+                            width="100%",
+                            height="80vh",
+                        ),
+                    ),
+                ),
+            ),
+        ),
     )
-

--- a/ui/umap_ui.py
+++ b/ui/umap_ui.py
@@ -22,7 +22,7 @@ def _figure_legend_panel(suffix: str):
                     ui.input_numeric(
                         f"umap_fig_width{suffix}",
                         "Figure width",
-                        value=12,
+                        value=10,
                         min=4,
                         max=30,
                     ),
@@ -32,7 +32,7 @@ def _figure_legend_panel(suffix: str):
                     ui.input_numeric(
                         f"umap_fig_height{suffix}",
                         "Figure height",
-                        value=12,
+                        value=8,
                         min=4,
                         max=30,
                     ),
@@ -44,7 +44,7 @@ def _figure_legend_panel(suffix: str):
                     ui.input_numeric(
                         f"umap_fig_dpi{suffix}",
                         "DPI",
-                        value=300,
+                        value=110,
                         min=72,
                         max=600,
                     ),
@@ -54,28 +54,33 @@ def _figure_legend_panel(suffix: str):
                     ui.input_numeric(
                         f"umap_font_size{suffix}",
                         "Font size",
-                        value=12,
+                        value=8,
                         min=6,
                         max=24,
                     ),
                 ),
             ),
-            ui.input_select(
-                f"umap_legend_location{suffix}",
-                "Legend location",
-                choices=[
-                    "best",
-                    "upper right",
-                    "upper left",
-                    "lower left",
-                    "lower right",
-                    "center left",
-                    "center right",
-                    "lower center",
-                    "upper center",
-                    "center",
-                ],
-                selected="best",
+            ui.row(
+                ui.column(
+                    12,
+                    ui.input_select(
+                        f"umap_legend_location{suffix}",
+                        "Legend location",
+                        choices=[
+                            "best",
+                            "upper right",
+                            "upper left",
+                            "lower left",
+                            "lower right",
+                            "center left",
+                            "center right",
+                            "lower center",
+                            "upper center",
+                            "center",
+                        ],
+                        selected="upper right",
+                    ),
+                ),
             ),
             ui.row(
                 ui.column(
@@ -83,7 +88,7 @@ def _figure_legend_panel(suffix: str):
                     ui.input_numeric(
                         f"umap_legend_font_size{suffix}",
                         "Legend font size",
-                        value=16,
+                        value=8,
                         min=6,
                         max=32,
                     ),
@@ -93,7 +98,7 @@ def _figure_legend_panel(suffix: str):
                     ui.input_numeric(
                         f"umap_legend_marker_scale{suffix}",
                         "Legend marker scale",
-                        value=5.0,
+                        value=1.5,
                         min=0.5,
                         max=20,
                         step=0.5,


### PR DESCRIPTION
## Summary
This PR refactors UMAP plotting to use the SPAC template path via `run_from_json` (`spac.templates.umap_tsne_pca_template`) instead of direct `dimensionality_reduction_plot` calls, while keeping visual output close to prior behavior. The server now maps UMAP UI state into template-compatible parameters and renders both UMAP panels through the same template-driven flow.

It also adds targeted graph customization controls for users: **Set feature color min/max (Feature mode only)** and **Show figure & legend settings** (figure size, DPI, font size, legend font size, legend marker scale). 

## Files Changed

- `server/umap_server.py`
  - Replaced direct `spac.visualization.dimensionality_reduction_plot` calls with template-based `run_from_json` rendering (`spac.templates.umap_tsne_pca_template`).
  - Added server-side parameter mapping for Annotation/Feature modes (including table/layer selection, point size, optional value min/max, and figure/legend sizing fields).
  - Continued using memory-object registration for `Upstream_Analysis` to support template execution on in-memory AnnData.
  - Added light figure layout post-processing to reduce axis-label clipping.

- `ui/umap_ui.py`
  - Added collapsible UMAP customization controls for:
    - **Set feature color min/max (Feature mode only)**
    - **Show figure & legend settings** (figure width/height, DPI, font size, legend font size, legend marker scale)

Example of default vs. customized UMAP graph:
    
<img width="2495" height="1000" alt="UMAP_refactoring" src="https://github.com/user-attachments/assets/dae15f7e-1617-4e4b-b3ef-680b64b1cded" />

## Testing (Manual Local Validation)
Validated behavior in the local Docker environment by rendering both UMAP panels across Annotation and Feature modes and verifying plots rendered successfully with the updated UMAP implementation. Reviewed container/application logs during testing and observed no runtime errors related to UMAP rendering or the new customization controls (feature min/max, figure/legend settings).

