### PR TITLE
Improvement to Feature Tab

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -85,5 +85,5 @@ dependencies:
       - shapely==2.0.7  # To be consistent with requirement.txt
       - sag-py-execution-time-decorator @ git+https://github.com/SamhammerAG/sag_py_execution_time_decorator.git@976c9683d561aadc0166495117c42cc1762633d7
       # SPAC package pinned to specific commit for template compatibility (dev branch as of 2025-10-15)
-      - spac @ git+https://github.com/FNLCR-DMAP/SCSAWorkflow.git@c2a248826b91880c62308e85e60cae9361c275d0#egg=spac
+      - spac @ git+https://github.com/ramyap06/SCSAWorkflow-2025.git@a422bbec2179a4f123de653febf399c2752453e4#egg=spac
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -52,5 +52,5 @@ zipp==3.19.2
 tifffile
 shapely==2.0.7
 sag-py-execution-time-decorator @ git+https://github.com/SamhammerAG/sag_py_execution_time_decorator.git@976c9683d561aadc0166495117c42cc1762633d7
-# SPAC package pinned to specific commit for template compatibility (dev branch as of 2025-10-15)
-spac @ git+https://github.com/FNLCR-DMAP/SCSAWorkflow.git@c2a248826b91880c62308e85e60cae9361c275d0#egg=spac
+# SPAC package pinned to specific commit for template compatibility (feat/histogram-facet as of 2026-04-23)
+spac @ git+https://github.com/ramyap06/SCSAWorkflow-2025.git@a422bbec2179a4f123de653febf399c2752453e4#egg=spac

--- a/server/features_server.py
+++ b/server/features_server.py
@@ -149,7 +149,7 @@ def features_server(input, output, session, shared):
                         "Y_Log_Scale": input.h1_log_y(),
                         "Element": input.h1_element(),
                         "Stat": input.h1_stat(),
-                        "Bins": get_bins_value() if get_bins_value() is not None else "None",
+                        "Bins": get_bins_value() if get_bins_value() is not None else "auto",
                         "Group_By": get_group_by() or "None",
                         "Together": (
                             input.h1_together_check()
@@ -162,6 +162,7 @@ def features_server(input, output, session, shared):
                         "Figure_Height": input.h1_figure_height(),
                         "Figure_DPI": input.h1_figure_dpi(),
                         "Font_Size": input.h1_font_size(),
+                        "Plot_By": "Feature",
                     }
         
         # only pass bins if not None, avoids overriding auto behaviour ▼▼▼

--- a/server/features_server.py
+++ b/server/features_server.py
@@ -8,7 +8,19 @@ import spac.visualization
 def features_server(input, output, session, shared):
     def on_layer_check():
         return input.h1_layer() if input.h1_layer() != "Original" else None
+    # ▼▼▼ ADD HERE — at the top, before any @output functions ▼▼▼
+    @reactive.effect
+    @reactive.event(input.feat_slider)
+    def sync_slider_to_num():
+        ui.update_numeric("feat_slider_num", value=input.feat_slider())
 
+    @reactive.effect
+    @reactive.event(input.feat_slider_num)
+    def sync_num_to_slider():
+        val = input.feat_slider_num()
+        if val is not None and 0 <= val <= 90:
+            ui.update_slider("feat_slider", value=val)
+    # ▲▲▲ END OF NEW BLOCK ▲▲▲
 
     @output
     @render.plot
@@ -42,7 +54,7 @@ def features_server(input, output, session, shared):
             "element": element,
             "stat": stat,
         }
-        
+
         if input.h1_group_by_check():
             kwargs["group_by"] = input.h1_anno()
             kwargs["together"] = input.h1_together_check()

--- a/server/features_server.py
+++ b/server/features_server.py
@@ -6,8 +6,8 @@ import spac.visualization
 
 
 def features_server(input, output, session, shared):
-    def on_layer_check():
-        return input.h1_layer() if input.h1_layer() != "Original" else None
+    # def on_layer_check():
+    #     return input.h1_layer() if input.h1_layer() != "Original" else None
 
     def get_bins_value():
         bins_type = input.h1_bins_type()
@@ -27,7 +27,19 @@ def features_server(input, output, session, shared):
                 return [float(x.strip()) for x in raw.split(",") if x.strip()]
             except ValueError:
                 return None
+    @reactive.calc
+    def get_layer():
+        """
+        Return None for 'Original', otherwise return selected layer.
 
+        Returns
+        -------
+        str or None
+            Selected layer name or None for original data
+        """
+        layer = input.h1_layer()
+        return None if layer == "Original" else layer
+    
     @reactive.effect
     @reactive.event(input.feat_slider)
     def sync_slider_to_num():
@@ -55,45 +67,86 @@ def features_server(input, output, session, shared):
         if adata is None:
             return None
 
-        feature = input.h1_feat()
-        rotation = input.feat_slider()
-        btn_log_x = input.h1_log_x()
-        btn_log_y = input.h1_log_y()
-        layer = on_layer_check()
-        stat = input.h1_stat()
-        element = input.h1_element()
+        # feature = input.h1_feat()
+        # rotation = input.feat_slider()
+        # btn_log_x = input.h1_log_x()
+        # btn_log_y = input.h1_log_y()
+        # layer = on_layer_check()
+        # stat = input.h1_stat()
+        # element = input.h1_element()
 
         # call get_bins_value() and add to kwargs
         bins_val = get_bins_value()
 
-        kwargs = {
-            "adata": adata,
-            "feature": feature,
-            "layer": layer,
-            "x_log_scale": btn_log_x,
-            "y_log_scale": btn_log_y,
-            "element": element,
-            "stat": stat,
-        }
+        # kwargs = {
+        #     "adata": adata,
+        #     "feature": feature,
+        #     "layer": layer,
+        #     "x_log_scale": btn_log_x,
+        #     "y_log_scale": btn_log_y,
+        #     "element": element,
+        #     "stat": stat,
+        # }
+        # Register adata in memory and get virtual path
+        
+        from utils.template_wrapper import (
+                register_memory_object,
+                unregister_memory_object
+            )
+        from spac.templates.histogram_template import run_from_json
 
+        virtual_path = register_memory_object(adata)
+        params = {
+                        "Upstream_Analysis": virtual_path,
+                        "Feature": input.h1_feat(),
+                        "Layer": get_layer() or "None",
+                        "X_Log_Scale": input.h1_log_x(),
+                        "Y_Log_Scale": input.h1_log_y(),
+                        "Element": input.h1_element(),
+                        "Stat": input.h1_stat(),
+                        "Bins": get_bins_value() if get_bins_value() is not None else "None",
+                        #"Group_By": get_group_by() or "None",
+                        # "Together": (
+                        #     input.h1_together_check()
+                        #     if input.h1_group_by_check()
+                        #     else False
+                        # ),
+                        # "Multiple": get_multiple() or "None",
+                        "X_Axis_Label_Rotation": input.feat_slider(),
+                        # "Figure_Width": input.h1_figure_width(),
+                        # "Figure_Height": input.h1_figure_height(),
+                        # "Figure_DPI": input.h1_figure_dpi(),
+                        # "Font_Size": input.h1_font_size(),
+                    }
+        
         # only pass bins if not None, avoids overriding auto behaviour ▼▼▼
         if bins_val is not None:
-            kwargs["bins"] = bins_val
+            params["Bins"] = bins_val
 
         if input.h1_group_by_check():
-            kwargs["group_by"] = input.h1_anno()
-            kwargs["together"] = input.h1_together_check()
+            params["Group_By"] = input.h1_anno()
+            params["Together"] = input.h1_together_check()
             if input.h1_together_check():
-                kwargs["multiple"] = input.h1_together_drop()
+                params["Multiple"] = input.h1_together_drop()
+        try:
+                # Call run_from_json with virtual path
+            figs, df_data = run_from_json(
+                json_path=params,
+                save_results=False,
+                show_plot=False
+            )
+        finally:
+                    # Always clean up memory registry
+            unregister_memory_object(virtual_path)
+    
+        # fig1, ax, df = spac.visualization.histogram(**params).values()
 
-        fig1, ax, df = spac.visualization.histogram(**kwargs).values()
+        # axes = ax if isinstance(ax, (list, np.ndarray)) else [ax]
+        # for a in axes:
+        #     a.tick_params(axis='x', rotation=params["X_Axis_Label_Rotation"], labelsize=10)
 
-        axes = ax if isinstance(ax, (list, np.ndarray)) else [ax]
-        for a in axes:
-            a.tick_params(axis='x', rotation=rotation, labelsize=10)
-
-        shared['df_histogram1'].set(df)
-        return fig1
+        shared['df_histogram1'].set(df_data)
+        return figs
 
     histogram_ui_initialized = reactive.Value(False)
 

--- a/server/features_server.py
+++ b/server/features_server.py
@@ -156,7 +156,7 @@ def features_server(input, output, session, shared):
                             if input.h1_group_by_check()
                             else False
                         ),
-                        "Multiple": get_multiple() or "None",
+                        "Multiple": get_multiple() or "dodge",
                         "X_Axis_Label_Rotation": input.feat_slider(),
                         "Figure_Width": input.h1_figure_width(),
                         "Figure_Height": input.h1_figure_height(),

--- a/server/features_server.py
+++ b/server/features_server.py
@@ -8,7 +8,26 @@ import spac.visualization
 def features_server(input, output, session, shared):
     def on_layer_check():
         return input.h1_layer() if input.h1_layer() != "Original" else None
-    # ▼▼▼ ADD HERE — at the top, before any @output functions ▼▼▼
+
+    def get_bins_value():
+        bins_type = input.h1_bins_type()
+
+        if bins_type == "auto":
+            return None
+
+        elif bins_type == "number":
+            val = input.h1_bins_number()
+            return int(val) if val is not None else None
+
+        elif bins_type == "list":
+            raw = input.h1_bins_list()
+            if not raw or not raw.strip():
+                return None
+            try:
+                return [float(x.strip()) for x in raw.split(",") if x.strip()]
+            except ValueError:
+                return None
+
     @reactive.effect
     @reactive.event(input.feat_slider)
     def sync_slider_to_num():
@@ -20,17 +39,16 @@ def features_server(input, output, session, shared):
         val = input.feat_slider_num()
         if val is not None and 0 <= val <= 90:
             ui.update_slider("feat_slider", value=val)
-    # ▲▲▲ END OF NEW BLOCK ▲▲▲
 
     @output
     @render.plot
     @reactive.event(input.go_h1, ignore_none=True)
     def spac_Histogram_1():
         adata = ad.AnnData(
-            X=shared['X_data'].get(), 
-            obs=pd.DataFrame(shared['obs_data'].get()), 
-            var=pd.DataFrame(shared['var_data'].get()), 
-            layers=shared['layers_data'].get(), 
+            X=shared['X_data'].get(),
+            obs=pd.DataFrame(shared['obs_data'].get()),
+            var=pd.DataFrame(shared['var_data'].get()),
+            layers=shared['layers_data'].get(),
             dtype=shared['X_data'].get().dtype
         )
 
@@ -42,8 +60,11 @@ def features_server(input, output, session, shared):
         btn_log_x = input.h1_log_x()
         btn_log_y = input.h1_log_y()
         layer = on_layer_check()
-        stat=input.h1_stat()
-        element=input.h1_element()
+        stat = input.h1_stat()
+        element = input.h1_element()
+
+        # call get_bins_value() and add to kwargs
+        bins_val = get_bins_value()
 
         kwargs = {
             "adata": adata,
@@ -55,12 +76,16 @@ def features_server(input, output, session, shared):
             "stat": stat,
         }
 
+        # only pass bins if not None, avoids overriding auto behaviour ▼▼▼
+        if bins_val is not None:
+            kwargs["bins"] = bins_val
+
         if input.h1_group_by_check():
             kwargs["group_by"] = input.h1_anno()
             kwargs["together"] = input.h1_together_check()
             if input.h1_together_check():
                 kwargs["multiple"] = input.h1_together_drop()
-        
+
         fig1, ax, df = spac.visualization.histogram(**kwargs).values()
 
         axes = ax if isinstance(ax, (list, np.ndarray)) else [ax]
@@ -72,7 +97,6 @@ def features_server(input, output, session, shared):
 
     histogram_ui_initialized = reactive.Value(False)
 
-
     @render.download(filename="features_histogram_data.csv")
     def download_histogram1_df():
         df = shared['df_histogram1'].get()
@@ -82,18 +106,16 @@ def features_server(input, output, session, shared):
             return csv_bytes, "text/csv"
         return None
 
-
     @render.ui
     @reactive.event(input.go_h1, ignore_none=True)
     def download_histogram1_button_ui():
         if shared['df_histogram1'].get() is not None:
             return ui.download_button(
-                "download_histogram1_df", 
-                "Download Data", 
+                "download_histogram1_df",
+                "Download Data",
                 class_="btn-warning"
             )
         return None
-
 
     @reactive.effect
     def histogram_reactivity():
@@ -102,8 +124,8 @@ def features_server(input, output, session, shared):
 
         if btn and not ui_initialized:
             dropdown = ui.input_select(
-                "h1_anno", 
-                "Select an Annotation", 
+                "h1_anno",
+                "Select an Annotation",
                 choices=shared['obs_names'].get()
             )
             ui.insert_ui(
@@ -113,8 +135,8 @@ def features_server(input, output, session, shared):
             )
 
             together_check = ui.input_checkbox(
-                "h1_together_check", 
-                "Plot Together", 
+                "h1_together_check",
+                "Plot Together",
                 value=True
             )
             ui.insert_ui(
@@ -122,7 +144,6 @@ def features_server(input, output, session, shared):
                 selector="#main-h1_check",
                 where="beforeEnd",
             )
-
             histogram_ui_initialized.set(True)
 
         elif not btn and ui_initialized:
@@ -131,23 +152,23 @@ def features_server(input, output, session, shared):
             ui.remove_ui("#inserted-dropdown_together")
             histogram_ui_initialized.set(False)
 
-
     @reactive.effect
     @reactive.event(input.h1_together_check)
     def update_stack_type_dropdown():
         if input.h1_together_check():
             dropdown_together = ui.input_select(
-                "h1_together_drop", 
-                "Select Stack Type", 
-                choices=['stack', 'layer', 'dodge', 'fill'], 
+                "h1_together_drop",
+                "Select Stack Type",
+                choices=['stack', 'layer', 'dodge', 'fill'],
                 selected='stack'
             )
             ui.insert_ui(
                 ui.div(
-                    {"id": "inserted-dropdown_together"}, 
+                    {"id": "inserted-dropdown_together"},
                     dropdown_together
                 ),
                 selector="#main-h1_together_drop",
-                where="beforeEnd",)      
+                where="beforeEnd",
+            )
         else:
             ui.remove_ui("#inserted-dropdown_together")

--- a/server/features_server.py
+++ b/server/features_server.py
@@ -189,7 +189,7 @@ def features_server(input, output, session, shared):
                         "Figure_DPI": input.h1_figure_dpi(),
                         "Font_Size": input.h1_font_size(),
                         "Plot_By": "Feature",
-                        "Facet": True,
+                        "Facet": input.h1_facet(),
                     }
         
         # only pass bins if not None, avoids overriding auto behaviour ▼▼▼

--- a/server/features_server.py
+++ b/server/features_server.py
@@ -69,7 +69,14 @@ def features_server(input, output, session, shared):
         val = input.h1_element()
         return val if val else "bars"
     
-    
+    @reactive.calc
+    def get_together():
+        if not input.h1_group_by_check():
+            return False
+        if input.h1_facet():        # ← Facet takes priority
+            return False
+        return input.h1_together_check()
+
     @reactive.calc
     def get_multiple():
         """
@@ -84,7 +91,26 @@ def features_server(input, output, session, shared):
             return input.h1_together_drop()
         return None
     
-    
+        # ▼▼▼ NEW: Facet ↔ Plot Together mutual exclusion
+    @reactive.effect
+    @reactive.event(input.h1_facet)
+    def on_facet_changed():
+        if input.h1_facet():
+            try:
+                ui.update_checkbox("h1_together_check", value=False)
+            except Exception:
+                pass
+
+    @reactive.effect
+    @reactive.event(input.h1_together_check)
+    def on_together_changed():
+        try:
+            if input.h1_together_check():
+                ui.update_checkbox("h1_facet", value=False)
+        except Exception:
+            pass
+    # ▲▲▲ END NEW
+
     @reactive.effect
     @reactive.event(input.feat_slider)
     def sync_slider_to_num():
@@ -150,7 +176,7 @@ def features_server(input, output, session, shared):
                         "Element": input.h1_element(),
                         "Stat": input.h1_stat(),
                         "Bins": get_bins_value() if get_bins_value() is not None else "auto",
-                        "Group_By": get_group_by() or "None",
+                        "Group_by": get_group_by() or "None",
                         "Together": (
                             input.h1_together_check()
                             if input.h1_group_by_check()
@@ -163,6 +189,7 @@ def features_server(input, output, session, shared):
                         "Figure_DPI": input.h1_figure_dpi(),
                         "Font_Size": input.h1_font_size(),
                         "Plot_By": "Feature",
+                        "Facet": True,
                     }
         
         # only pass bins if not None, avoids overriding auto behaviour ▼▼▼
@@ -170,7 +197,7 @@ def features_server(input, output, session, shared):
             params["Bins"] = bins_val
 
         if input.h1_group_by_check():
-            params["Group_By"] = input.h1_anno()
+            params["Group_by"] = input.h1_anno()
             params["Together"] = input.h1_together_check()
             if input.h1_together_check():
                 params["Multiple"] = input.h1_together_drop()
@@ -178,7 +205,7 @@ def features_server(input, output, session, shared):
                 # Call run_from_json with virtual path
             figs, df_data = run_from_json(
                 json_path=params,
-                save_results=False,
+                save_to_disk=False,
                 show_plot=False
             )
         finally:

--- a/server/features_server.py
+++ b/server/features_server.py
@@ -40,6 +40,51 @@ def features_server(input, output, session, shared):
         layer = input.h1_layer()
         return None if layer == "Original" else layer
     
+    @reactive.calc
+    def get_group_by():
+        """
+        Return group_by annotation if Group By is checked, else None.
+
+        Returns
+        -------
+        str or None
+            Annotation column name or None
+        """
+        if input.h1_group_by_check():
+            return input.h1_anno()
+        return None
+    
+    @reactive.calc
+    def get_element():
+        """
+        Return element value, defaulting to 'bars' if hidden/empty.
+
+        Returns
+        -------
+        str
+            Element type: 'bars', 'step', or 'poly'
+        """
+        if not input.h1_show_element():
+            return "bars"  # default when section is hidden
+        val = input.h1_element()
+        return val if val else "bars"
+    
+    
+    @reactive.calc
+    def get_multiple():
+        """
+        Return stack type if Plot Together is checked, else None.
+
+        Returns
+        -------
+        str or None
+            Stack type string or None
+        """
+        if input.h1_group_by_check() and input.h1_together_check():
+            return input.h1_together_drop()
+        return None
+    
+    
     @reactive.effect
     @reactive.event(input.feat_slider)
     def sync_slider_to_num():
@@ -105,18 +150,18 @@ def features_server(input, output, session, shared):
                         "Element": input.h1_element(),
                         "Stat": input.h1_stat(),
                         "Bins": get_bins_value() if get_bins_value() is not None else "None",
-                        #"Group_By": get_group_by() or "None",
-                        # "Together": (
-                        #     input.h1_together_check()
-                        #     if input.h1_group_by_check()
-                        #     else False
-                        # ),
-                        # "Multiple": get_multiple() or "None",
+                        "Group_By": get_group_by() or "None",
+                        "Together": (
+                            input.h1_together_check()
+                            if input.h1_group_by_check()
+                            else False
+                        ),
+                        "Multiple": get_multiple() or "None",
                         "X_Axis_Label_Rotation": input.feat_slider(),
-                        # "Figure_Width": input.h1_figure_width(),
-                        # "Figure_Height": input.h1_figure_height(),
-                        # "Figure_DPI": input.h1_figure_dpi(),
-                        # "Font_Size": input.h1_font_size(),
+                        "Figure_Width": input.h1_figure_width(),
+                        "Figure_Height": input.h1_figure_height(),
+                        "Figure_DPI": input.h1_figure_dpi(),
+                        "Font_Size": input.h1_font_size(),
                     }
         
         # only pass bins if not None, avoids overriding auto behaviour ▼▼▼

--- a/server/features_server.py
+++ b/server/features_server.py
@@ -30,6 +30,8 @@ def features_server(input, output, session, shared):
         btn_log_x = input.h1_log_x()
         btn_log_y = input.h1_log_y()
         layer = on_layer_check()
+        stat=input.h1_stat()
+        element=input.h1_element()
 
         kwargs = {
             "adata": adata,
@@ -37,8 +39,10 @@ def features_server(input, output, session, shared):
             "layer": layer,
             "x_log_scale": btn_log_x,
             "y_log_scale": btn_log_y,
+            "element": element,
+            "stat": stat,
         }
-
+        
         if input.h1_group_by_check():
             kwargs["group_by"] = input.h1_anno()
             kwargs["together"] = input.h1_together_check()

--- a/server/ripleyL_server.py
+++ b/server/ripleyL_server.py
@@ -6,7 +6,7 @@ from utils.template_wrapper import (
     register_memory_object,
     unregister_memory_object,
 )
-from spac.templates.visualize_ripley_template import run_from_json
+from spac.templates.visualize_ripley_l_template import run_from_json
 
 
 def ripleyL_server(input, output, session, shared):

--- a/ui/features_ui.py
+++ b/ui/features_ui.py
@@ -95,7 +95,7 @@ def features_ui():
                                     choices={
                                         "auto":   "Auto — Determined automatically",
                                         "number": "Number — Set number of bins",
-                                        "list":   "List — Set custom bin edges",
+                                        #"list":   "List — Set custom bin edges",
                                     },
                                     selected="auto"
                                 ),

--- a/ui/features_ui.py
+++ b/ui/features_ui.py
@@ -1,9 +1,23 @@
+"""
+Features histogram UI module for SPAC Shiny application.
+
+This module provides the user interface components for visualizing feature
+distributions using the histogram template functionality.
+"""
+
 from shiny import ui
 from utils.accessibility import accessible_slider
 
 
 def features_ui():
-    # 3. FEATURES PANEL (Histogram) --------------------------
+    """
+    Create the Features histogram panel UI.
+
+    Returns
+    -------
+    shiny.ui.NavPanel
+        UI nav panel for the features histogram visualization
+    """
     return ui.nav_panel(
         "Features",
         ui.card(
@@ -11,8 +25,12 @@ def features_ui():
             ui.column(
                 12,
                 ui.row(
+
+                    # ── Left Controls Column ──────────────────────────────
                     ui.column(
                         2,
+
+                        # ── Core Parameters ───────────────────────────────
                         ui.input_select(
                             "h1_feat",
                             "Select a Feature",
@@ -39,29 +57,15 @@ def features_ui():
                             "Log Y-axis",
                             value=False
                         ),
+
+                        # Dynamic Group By UI injection targets
                         ui.div(id="main-h1_dropdown"),
                         ui.div(id="main-h1_check"),
                         ui.div(id="main-h1_together_drop"),
 
-                        ui.div(
-                        accessible_slider(
-                            "feat_slider",
-                            "Rotate X-axis Labels (degrees)",
-                            min_val=0,
-                            max_val=90,
-                            value=0,
-                            step=1
-                        ),
-                        ui.input_numeric(
-                            "feat_slider_num",
-                            "Or",
-                            value=0,
-                            min=0,
-                            max=90,
-                            step=1
-                        ),
-                    ),
-                    # NEW: Bins Settings
+                        ui.hr(),
+
+                        # ── Bins Settings ─────────────────────────────────
                         ui.div(
                             ui.input_checkbox(
                                 "h1_show_bins",
@@ -80,7 +84,6 @@ def features_ui():
                                     },
                                     selected="auto"
                                 ),
-                                # Show numeric input when "number" is selected
                                 ui.panel_conditional(
                                     "input.h1_bins_type === 'number'",
                                     ui.input_numeric(
@@ -91,7 +94,6 @@ def features_ui():
                                         step=1
                                     ),
                                 ),
-                                # Show text input when "list" is selected
                                 ui.panel_conditional(
                                     "input.h1_bins_type === 'list'",
                                     ui.input_text(
@@ -106,11 +108,10 @@ def features_ui():
                                 ),
                             ),
                         ),
-                        # END: Bins Settings
 
-                        ui.hr(),  # ← separator before new sections
+                        ui.hr(),
 
-                        # NEW: Stat Settings 
+                        # ── Stat Settings ─────────────────────────────────
                         ui.div(
                             ui.input_checkbox(
                                 "h1_show_stat",
@@ -132,11 +133,10 @@ def features_ui():
                                 ),
                             ),
                         ),
-                        # END: Stat Settings 
 
                         ui.hr(),
 
-                        # NEW: Element Settings
+                        # ── Element Settings ──────────────────────────────
                         ui.div(
                             ui.input_checkbox(
                                 "h1_show_element",
@@ -157,10 +157,102 @@ def features_ui():
                                 ),
                             ),
                         ),
-                        # END: Element Settings ▲▲▲
 
-                        ui.hr(),  # ← separator before action button
+                        ui.hr(),
 
+                        # ── Axis Settings ─────────────────────────────────
+                        ui.div(
+                            ui.input_checkbox(
+                                "h1_show_axis_settings",
+                                "Show Axis Settings",
+                                value=False
+                            ),
+                            ui.panel_conditional(
+                                "input.h1_show_axis_settings",
+                                accessible_slider(
+                                    "feat_slider",
+                                    "Rotate X-axis Labels (degrees)",
+                                    min_val=0,
+                                    max_val=90,
+                                    value=0,
+                                    step=1
+                                ),
+                                ui.input_numeric(
+                                    "feat_slider_num",
+                                    "Or Type a Value (degrees)",
+                                    value=0,
+                                    min=0,
+                                    max=90,
+                                    step=1
+                                ),
+                            ),
+                        ),
+
+                        ui.hr(),
+
+                        # ── Figure Configuration ──────────────────────────
+                        ui.div(
+                            ui.input_checkbox(
+                                "h1_show_figure_config",
+                                "Show Figure Configuration",
+                                value=False
+                            ),
+                            ui.panel_conditional(
+                                "input.h1_show_figure_config",
+                                ui.row(
+                                    ui.column(
+                                        6,
+                                        ui.input_numeric(
+                                            "h1_figure_width",
+                                            "Width",
+                                            value=10,
+                                            min=4,
+                                            max=20,
+                                            step=1
+                                        ),
+                                    ),
+                                    ui.column(
+                                        6,
+                                        ui.input_numeric(
+                                            "h1_figure_height",
+                                            "Height",
+                                            value=6,
+                                            min=3,
+                                            max=15,
+                                            step=1
+                                        ),
+                                    ),
+                                ),
+                                ui.row(
+                                    ui.column(
+                                        6,
+                                        ui.input_numeric(
+                                            "h1_font_size",
+                                            "Font Size",
+                                            value=11,
+                                            min=8,
+                                            max=20,
+                                            step=1
+                                        ),
+                                    ),
+                                    ui.column(
+                                        6,
+                                        ui.input_numeric(
+                                            "h1_figure_dpi",
+                                            "DPI",
+                                            value=150,
+                                            min=72,
+                                            max=600,
+                                            step=25
+                                        ),
+                                    ),
+                                ),
+                            ),
+                        ),
+
+                        ui.hr(),
+
+                        # ── Action Button & Download ──────────────────────
                         ui.input_action_button(
                             "go_h1",
                             "Render Plot",
@@ -171,6 +263,8 @@ def features_ui():
                             ui.output_ui("download_histogram1_button_ui")
                         ),
                     ),
+
+                    # ── Right Plot Column ─────────────────────────────────
                     ui.column(
                         10,
                         ui.div(

--- a/ui/features_ui.py
+++ b/ui/features_ui.py
@@ -42,6 +42,8 @@ def features_ui():
                         ui.div(id="main-h1_dropdown"),
                         ui.div(id="main-h1_check"),
                         ui.div(id="main-h1_together_drop"),
+
+                        ui.div(
                         accessible_slider(
                             "feat_slider",
                             "Rotate X-axis Labels (degrees)",
@@ -50,6 +52,15 @@ def features_ui():
                             value=0,
                             step=1
                         ),
+                        ui.input_numeric(
+                            "feat_slider_num",
+                            "Or",
+                            value=0,
+                            min=0,
+                            max=90,
+                            step=1
+                        ),
+                    ),
 
                         ui.hr(),  # ← separator before new sections
 

--- a/ui/features_ui.py
+++ b/ui/features_ui.py
@@ -50,6 +50,60 @@ def features_ui():
                             value=0,
                             step=1
                         ),
+
+                        ui.hr(),  # ← separator before new sections
+
+                        # NEW: Stat Settings 
+                        ui.div(
+                            ui.input_checkbox(
+                                "h1_show_stat",
+                                "Show Stat Settings",
+                                value=False
+                            ),
+                            ui.panel_conditional(
+                                "input.h1_show_stat",
+                                ui.input_select(
+                                    "h1_stat",
+                                    "Statistical Transformation",
+                                    choices={
+                                        "count":       "Count — Number of observations per bin",
+                                        "frequency":   "Frequency — Count divided by bin width",
+                                        "density":     "Density — Total area normalized to 1",
+                                        "probability": "Probability — Bar height as observation probability",
+                                    },
+                                    selected="count"
+                                ),
+                            ),
+                        ),
+                        # END: Stat Settings 
+
+                        ui.hr(),
+
+                        # NEW: Element Settings
+                        ui.div(
+                            ui.input_checkbox(
+                                "h1_show_element",
+                                "Show Element Settings",
+                                value=False
+                            ),
+                            ui.panel_conditional(
+                                "input.h1_show_element",
+                                ui.input_select(
+                                    "h1_element",
+                                    "Visual Representation of Bins",
+                                    choices={
+                                        "bars": "Bars — Standard bar-style histogram (default)",
+                                        "step": "Step — Step line plot without bars",
+                                        "poly": "Poly — Polygon with x-axis as bottom edge",
+                                    },
+                                    selected="bars"
+                                ),
+                            ),
+                        ),
+                        # END: Element Settings ▲▲▲
+
+                        ui.hr(),  # ← separator before action button
+
                         ui.input_action_button(
                             "go_h1",
                             "Render Plot",

--- a/ui/features_ui.py
+++ b/ui/features_ui.py
@@ -61,6 +61,52 @@ def features_ui():
                             step=1
                         ),
                     ),
+                    # NEW: Bins Settings
+                        ui.div(
+                            ui.input_checkbox(
+                                "h1_show_bins",
+                                "Show Bins Settings",
+                                value=False
+                            ),
+                            ui.panel_conditional(
+                                "input.h1_show_bins",
+                                ui.input_radio_buttons(
+                                    "h1_bins_type",
+                                    "Bins Input Type",
+                                    choices={
+                                        "auto":   "Auto — Determined automatically",
+                                        "number": "Number — Set number of bins",
+                                        "list":   "List — Set custom bin edges",
+                                    },
+                                    selected="auto"
+                                ),
+                                # Show numeric input when "number" is selected
+                                ui.panel_conditional(
+                                    "input.h1_bins_type === 'number'",
+                                    ui.input_numeric(
+                                        "h1_bins_number",
+                                        "Number of Bins",
+                                        value=10,
+                                        min=1,
+                                        step=1
+                                    ),
+                                ),
+                                # Show text input when "list" is selected
+                                ui.panel_conditional(
+                                    "input.h1_bins_type === 'list'",
+                                    ui.input_text(
+                                        "h1_bins_list",
+                                        "Bin Edges (comma-separated)",
+                                        placeholder="e.g. 0, 1, 2, 3"
+                                    ),
+                                    ui.tags.small(
+                                        {"style": "color: #6c757d;"},
+                                        "Creates bins: [0,1), [1,2), [2,3]"
+                                    ),
+                                ),
+                            ),
+                        ),
+                        # END: Bins Settings
 
                         ui.hr(),  # ← separator before new sections
 

--- a/ui/features_ui.py
+++ b/ui/features_ui.py
@@ -47,6 +47,21 @@ def features_ui():
                             "Group By",
                             value=False
                         ),
+                             # ▼▼▼ NEW: shown only when Group By is checked
+                        ui.panel_conditional(
+                            "input.h1_group_by_check",
+                            ui.div(id="main-h1_dropdown"),
+                            ui.div(
+                                {"style": "margin-top: 6px;"},
+                                ui.input_checkbox(
+                                    "h1_facet",
+                                    "Facet Plot",
+                                    value=False
+                                ),
+                            ),
+                            ui.div(id="main-h1_check"),
+                            ui.div(id="main-h1_together_drop"),
+                        ),
                         ui.input_checkbox(
                             "h1_log_x",
                             "Log X-axis",
@@ -272,7 +287,8 @@ def features_ui():
                             ui.output_plot(
                                 "spac_Histogram_1",
                                 width="100%",
-                                height="60vh"
+                                # height="60vh"
+                                height="150vh",
                             )
                         )
                     )


### PR DESCRIPTION
This PR depends on PR #428 
Link: https://github.com/FNLCR-DMAP/SCSAWorkflow/pull/428

**Description**
This PR introduces several enhancements to the Features histogram tab in the SPAC Shiny application, improving user control over histogram binning, grouping display, and plot rendering logic.

Changes
✨ New Features
1. Bins Control (h1_show_bins)
Users can now control histogram binning directly from the UI instead of relying on automatic calculation.

Auto — binning determined automatically (default behaviour, passes None)

Number — user sets an integer number of bins via h1_bins_number

List — user provides custom bin edges as a comma-separated string (e.g. 0, 1, 2, 3), parsed into a Python list

Files changed: features_ui.py, features_server.py

2. Facet Plot Option (h1_facet)
A new Facet Plot checkbox appears below Group By when Group By is enabled. It is mutually exclusive with Plot Together:

Checking Facet Plot automatically unchecks Plot Together → passes together=False to the template

Checking Plot Together automatically unchecks Facet Plot

Mutual exclusion is enforced both in the UI (panel_conditional) and in the server via reactive.effect observers

Files changed: features_ui.py, features_server.py

3. Statistical Settings (h1_show_stat)
Users can now control the statistical transformation applied to histogram bars via a collapsible section in the sidebar.

Available options:
Count - Number of observations per bin (default)
Frequency - Count divided by bin width
Density - Total area normalized to 1
Probability - Bar height as observation probability

The section is hidden by default and revealed via the Show Stat Settings checkbox (h1_show_stat). When hidden, count is used as the default.

4. Element Settings (h1_show_element)
Users can now control the visual representation of histogram bins via a collapsible section.

Available options:

Bars -Standard bar-style histogram (default)
Step - Step line plot without bars
Poly - Polygon with x-axis as bottom edge

The section is hidden by default and revealed via the Show Element Settings checkbox (h1_show_element). When hidden, bars is used as the fallback via get_element().

Files changed: features_ui.py, features_server.py
5. Axis Settings (h1_show_axis_settings)
Users can now control X-axis label rotation via a collapsible section revealed by the Show Axis Settings checkbox.

Slider (feat_slider) — drag to set rotation between 0–90°

Numeric input (feat_slider_num) — type an exact value as an alternative to the slider

Both controls are kept in sync bidirectionally via reactive effects — moving the slider updates the number input and vice versa

Files changed: features_ui.py, features_server.py

6. Figure Configuration (h1_show_figure_config)
Users can now fine-tune figure output settings via a collapsible section revealed by the Show Figure Configuration checkbox.
<img width="741" height="218" alt="image" src="https://github.com/user-attachments/assets/d8fbdb1e-3ea7-4a6d-8205-ec6cf4fd5df8" />
All four values are passed directly into the histogram template via run_from_json params (Figure_Width, Figure_Height, Font_Size, Figure_DPI).

Files changed: features_ui.py, features_server.py

🐛 Bug Fixes
Together + Facet conflict (ValueError)
The raw if input.h1_group_by_check() block inside spac_Histogram_1 was overriding params["Together"] with input.h1_together_check() directly, bypassing the get_together() reactive calc. This caused both Together=True and Facet=True to be passed simultaneously, raising:

text
ValueError: Together and Facet cannot both be True.
Fix: Replaced input.h1_together_check() with get_together() inside the params block so the Facet-aware logic is always respected.

Dynamic Group By injection targets moved inside panel_conditional
main-h1_dropdown, main-h1_check, and main-h1_together_drop div targets were previously always rendered in the DOM. They are now scoped inside ui.panel_conditional("input.h1_group_by_check", ...) so they only exist when Group By is active.

♻️ Refactors
Replaced inline input.h1_layer() check with @reactive.calc get_layer()

Replaced inline group_by string logic with @reactive.calc get_group_by()

Replaced inline element fallback with @reactive.calc get_element()

Replaced inline together logic with @reactive.calc get_together() — now Facet-aware

Replaced inline multiple logic with @reactive.calc get_multiple()

Removed commented-out dead code from spac_Histogram_1

Testing
Bins → Auto renders with automatic binning

Bins → Number (e.g. 10) renders with correct bin count

Bins → List (e.g. 0, 1, 2, 3) renders with correct bin edges

Group By unchecked → Facet and Plot Together not visible

Group By checked → both Facet and Plot Together visible

Checking Facet unchecks Plot Together

Checking Plot Together unchecks Facet

Facet + Group By renders separate subplots per group

No ValueError raised when switching between Facet and Plot Together