### PR TITLE
Download Naming Conventions

### DIFF
--- a/app.py
+++ b/app.py
@@ -116,6 +116,7 @@ def server(input, output, session):
 
     shared = {
         "preloaded_data": preloaded_data,  # Preloaded data for initial load
+        "preloaded_file_path": file_path,  # Path to preloaded file for filename extraction
         "data_loaded": data_loaded,  # Reactive to track if data is loaded
         "adata_main": adata_main,  # Main anndata object
     }
@@ -124,6 +125,9 @@ def server(input, output, session):
     # and add them to the shared dictionary
     for key in data_keys:
         shared[key] = reactive.Value(None)
+    
+    # Add reactive value for input filename
+    shared['input_filename'] = reactive.Value(None)
 
     # Individual server components
     getting_started_server(input, output, session, shared)

--- a/server/anno_vs_anno_server.py
+++ b/server/anno_vs_anno_server.py
@@ -3,6 +3,7 @@ from shinywidgets import render_widget
 import anndata as ad
 import pandas as pd
 import spac.visualization
+from utils.download_naming import build_download_filename
 
 def anno_vs_anno_server(input, output, session, shared):
 
@@ -43,7 +44,10 @@ def anno_vs_anno_server(input, output, session, shared):
             return result['figure']
         return None
 
-    @render.download(filename="relational_data.csv")
+    def get_relational_filename():
+        return build_download_filename(shared, "relational", mime_type="text/csv")
+
+    @render.download(filename=get_relational_filename)
     def download_df_1():
         df = shared['df_relational'].get()
         if df is not None:

--- a/server/annotations_server.py
+++ b/server/annotations_server.py
@@ -1,6 +1,7 @@
 from shiny import ui, render, reactive
 import numpy as np
 import spac.visualization
+from utils.download_naming import build_download_filename
 
 def annotations_server(input, output, session, shared):
     @output
@@ -68,7 +69,12 @@ def annotations_server(input, output, session, shared):
         return None
 
 
-    @render.download(filename="annotation_histogram_data.csv")
+    def get_annotation_histogram_filename():
+        return build_download_filename(
+            shared, "annotation_histogram", mime_type="text/csv"
+        )
+
+    @render.download(filename=get_annotation_histogram_filename)
     def download_histogram2_df():
         df = shared['df_histogram2'].get()
         if df is not None:

--- a/server/boxplot_server.py
+++ b/server/boxplot_server.py
@@ -66,7 +66,14 @@ def boxplot_server(input, output, session, shared):
         return None
 
 
-    @render.download(filename="boxplot_data.csv")
+    def get_boxplot_csv_filename():
+        """Generate CSV download filename."""
+        input_filename = shared['input_filename'].get()
+        if input_filename:
+            return f"{input_filename}_boxplot.csv"
+        return "boxplot.csv"
+
+    @render.download(filename=get_boxplot_csv_filename)
     def download_boxplot():
         df = shared['df_boxplot'].get()
         if df is not None:
@@ -74,7 +81,6 @@ def boxplot_server(input, output, session, shared):
             csv_bytes = csv_string.encode("utf-8")
             return csv_bytes, "text/csv"
         return None
-
 
     @render.ui
     @reactive.event(input.go_bp, ignore_none=True)

--- a/server/boxplot_server.py
+++ b/server/boxplot_server.py
@@ -3,6 +3,7 @@ from shinywidgets import render_widget
 import anndata as ad
 import pandas as pd
 import spac.visualization
+from utils.download_naming import build_download_filename
 
 
 def boxplot_server(input, output, session, shared):
@@ -67,11 +68,8 @@ def boxplot_server(input, output, session, shared):
 
 
     def get_boxplot_csv_filename():
-        """Generate CSV download filename."""
-        input_filename = shared['input_filename'].get()
-        if input_filename:
-            return f"{input_filename}_boxplot.csv"
-        return "boxplot.csv"
+        """Generate dataset_boxplot CSV download filename."""
+        return build_download_filename(shared, "boxplot", mime_type="text/csv")
 
     @render.download(filename=get_boxplot_csv_filename)
     def download_boxplot():

--- a/server/data_input_server.py
+++ b/server/data_input_server.py
@@ -1,6 +1,22 @@
+import os
+import re
+
 from shiny import render, reactive
 import pickle
 import anndata as ad
+
+
+def sanitize_filename(filename):
+    """Extract base filename and sanitize it for use in download names."""
+    # Remove path and extension
+    base_name = os.path.splitext(os.path.basename(filename))[0]
+    # Replace spaces and special characters with underscores
+    sanitized = re.sub(r'[^a-zA-Z0-9_-]', '_', base_name)
+    # Remove multiple consecutive underscores
+    sanitized = re.sub(r'_+', '_', sanitized)
+    # Remove leading/trailing underscores
+    sanitized = sanitized.strip('_')
+    return sanitized
 
 
 def data_input_server(input, output, session, shared):
@@ -13,10 +29,18 @@ def data_input_server(input, output, session, shared):
             if shared['preloaded_data'] is not None:
                 shared['adata_main'].set(shared['preloaded_data'])
                 shared['data_loaded'].set(True)
+                # Extract filename from preloaded file path
+                preloaded_path = shared.get('preloaded_file_path', 'dev_example.pickle')
+                filename = sanitize_filename(preloaded_path)
+                shared['input_filename'].set(filename)
             else:
                 shared['data_loaded'].set(False)
+                shared['input_filename'].set(None)
         else:
             file_path = file_info[0]['datapath']
+            # Extract and store filename
+            filename = sanitize_filename(file_path)
+            shared['input_filename'].set(filename)
             with open(file_path, 'rb') as file:
                 if file_path.endswith('.pickle'):
                     shared['adata_main'].set(pickle.load(file))

--- a/server/feat_vs_anno_server.py
+++ b/server/feat_vs_anno_server.py
@@ -13,6 +13,7 @@ import pandas as pd
 import logging
 import spac.visualization
 from utils.plot_utils import abbreviate_labels, apply_axis_style
+from utils.download_naming import build_download_filename
 
 
 # Set up logger
@@ -185,7 +186,10 @@ def feat_vs_anno_server(input, output, session, shared):
         fig.fig.subplots_adjust(bottom=0.15, left=0)
         return fig
 
-    @render.download(filename="heatmap_data.csv")
+    def get_heatmap_filename():
+        return build_download_filename(shared, "heatmap", mime_type="text/csv")
+
+    @render.download(filename=get_heatmap_filename)
     def download_df_hm1():
         df = shared['df_heatmap'].get()
         if df is not None:

--- a/server/features_server.py
+++ b/server/features_server.py
@@ -3,6 +3,7 @@ import anndata as ad
 import numpy as np
 import pandas as pd
 import spac.visualization
+from utils.download_naming import build_download_filename
 
 
 def features_server(input, output, session, shared):
@@ -57,7 +58,12 @@ def features_server(input, output, session, shared):
     histogram_ui_initialized = reactive.Value(False)
 
 
-    @render.download(filename="features_histogram_data.csv")
+    def get_features_histogram_filename():
+        return build_download_filename(
+            shared, "features_histogram", mime_type="text/csv"
+        )
+
+    @render.download(filename=get_features_histogram_filename)
     def download_histogram1_df():
         df = shared['df_histogram1'].get()
         if df is not None:

--- a/server/nearest_neighbor_server.py
+++ b/server/nearest_neighbor_server.py
@@ -6,6 +6,7 @@ neighbor distances using the visualize_nearest_neighbor_template functionality.
 """
 
 from shiny import ui, render, reactive, req
+from utils.download_naming import build_download_filename
 
 
 def nearest_neighbor_server(input, output, session, shared):
@@ -252,7 +253,12 @@ def nearest_neighbor_server(input, output, session, shared):
             traceback.print_exc()
             return None
 
-    @render.download(filename="nearest_neighbor_data.csv")
+    def get_nearest_neighbor_filename():
+        return build_download_filename(
+            shared, "nearest_neighbor", mime_type="text/csv"
+        )
+
+    @render.download(filename=get_nearest_neighbor_filename)
     def download_df_nn():
         """
         Download the nearest neighbor data as CSV.

--- a/server/ripleyL_server.py
+++ b/server/ripleyL_server.py
@@ -1,6 +1,7 @@
 from shiny import ui, render, reactive
 import anndata as ad
 from typing import Tuple, Any
+from utils.download_naming import build_download_filename
 
 from utils.template_wrapper import (
     register_memory_object,
@@ -104,7 +105,10 @@ def ripleyL_server(input, output, session, shared):
                 # ignore cleanup errors
                 pass
 
-    @render.download(filename="ripley_plot_data.csv")
+    def get_ripley_filename():
+        return build_download_filename(shared, "ripley_plot", mime_type="text/csv")
+
+    @render.download(filename=get_ripley_filename)
     def download_df_rl():
         df = shared['df_ripley'].get()
         if df is not None:

--- a/utils/download_naming.py
+++ b/utils/download_naming.py
@@ -1,0 +1,52 @@
+"""Utilities for consistent download filename generation."""
+
+from __future__ import annotations
+
+from typing import Mapping
+
+
+MIME_TO_EXTENSION: Mapping[str, str] = {
+    "text/csv": "csv",
+    "text/html": "html",
+    "text/plain": "txt",
+    "text/tab-separated-values": "tsv",
+    "application/json": "json",
+    "application/pdf": "pdf",
+    "application/xml": "xml",
+    "application/zip": "zip",
+    "image/png": "png",
+    "image/jpeg": "jpg",
+    "image/webp": "webp",
+}
+
+
+def infer_extension(mime_type: str | None, default_extension: str = "bin") -> str:
+    """Infer file extension from MIME type."""
+    if not mime_type:
+        return default_extension
+    return MIME_TO_EXTENSION.get(mime_type.strip().lower(), default_extension)
+
+
+def build_download_filename(
+    shared,
+    graph_type: str,
+    extension: str | None = None,
+    mime_type: str | None = None,
+    default_extension: str = "bin",
+) -> str:
+    """Build filenames in the format dataset_graphtype.ext.
+
+    For future file types, callers can pass only `mime_type` and avoid hardcoding
+    extensions in each server module.
+    """
+    dataset_name = shared.get("input_filename")
+    if hasattr(dataset_name, "get"):
+        dataset_name = dataset_name.get()
+
+    if not dataset_name:
+        dataset_name = "dataset"
+
+    clean_graph_type = str(graph_type).strip().replace(" ", "_").lower()
+    resolved_extension = extension or infer_extension(mime_type, default_extension)
+    clean_extension = str(resolved_extension).strip().lstrip(".").lower()
+    return f"{dataset_name}_{clean_graph_type}.{clean_extension}"


### PR DESCRIPTION
## Summary
- Standardize download filenames to `dataset_graphtype` using the uploaded/preloaded dataset name
- Add shared download naming utility (`utils/download_naming.py`) with MIME-to-extension inference **for future file types**
- Migrate all current plot-data download handlers to use the shared naming utility, removing hardcoded per-handler filenames

### **Before** 
<img width="501" height="124" alt="image" src="https://github.com/user-attachments/assets/7025c840-3e76-45e0-aa64-69eb8c8842cb" />


### **After** 
<img width="553" height="162" alt="image" src="https://github.com/user-attachments/assets/429a0c81-83b9-4158-8dd8-042abc45cc1a" />



## Changes
- `app.py`
  - add shared reactive `input_filename`
  - pass `preloaded_file_path` to shared state
- `server/data_input_server.py`
  - add dataset filename sanitization and set `shared['input_filename']` for uploaded/preloaded data
- `utils/download_naming.py`
  - add centralized filename builder and MIME extension inference
- updated download handlers in:
  - `server/annotations_server.py`
  - `server/features_server.py`
  - `server/boxplot_server.py`
  - `server/feat_vs_anno_server.py`
  - `server/anno_vs_anno_server.py`
  - `server/nearest_neighbor_server.py`
  - `server/ripleyL_server.py`

## Testing Process:
Tested dataset uploads with spaces and special characters in the filename to verify sanitization behavior. Validated the Download Data functionality across all plot types and confirmed exported filenames follow the dataset_graphtype.csv naming convention. Also verified fallback behavior when no dataset name is available, ensuring files default to the dataset_graphtype.ext format.