### PR TITLE
chore(deps): pin SPAC to PR #433 and restore template compatibility

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -84,6 +84,5 @@ dependencies:
       - tifffile
       - shapely==2.0.7  # To be consistent with requirement.txt
       - sag-py-execution-time-decorator @ git+https://github.com/SamhammerAG/sag_py_execution_time_decorator.git@976c9683d561aadc0166495117c42cc1762633d7
-      # SPAC package pinned to specific commit for template compatibility (dev branch as of 2025-10-15)
-      - spac @ git+https://github.com/FNLCR-DMAP/SCSAWorkflow.git@c2a248826b91880c62308e85e60cae9361c275d0#egg=spac
-
+      # SPAC package pinned to the merge commit of PR #433 (dev branch as of 2026-08-04)
+      - spac @ git+https://github.com/FNLCR-DMAP/SCSAWorkflow.git@f9886bcde643ebf14e58a31d5ac397e28b6ea510#egg=spac

--- a/requirements.txt
+++ b/requirements.txt
@@ -52,5 +52,5 @@ zipp==3.19.2
 tifffile
 shapely==2.0.7
 sag-py-execution-time-decorator @ git+https://github.com/SamhammerAG/sag_py_execution_time_decorator.git@976c9683d561aadc0166495117c42cc1762633d7
-# SPAC package pinned to specific commit for template compatibility (dev branch as of 2025-10-15)
-spac @ git+https://github.com/FNLCR-DMAP/SCSAWorkflow.git@c2a248826b91880c62308e85e60cae9361c275d0#egg=spac
+# SPAC package pinned to the merge commit of PR #433 (dev branch as of 2026-08-04)
+spac @ git+https://github.com/FNLCR-DMAP/SCSAWorkflow.git@f9886bcde643ebf14e58a31d5ac397e28b6ea510#egg=spac

--- a/server/nearest_neighbor_server.py
+++ b/server/nearest_neighbor_server.py
@@ -222,7 +222,7 @@ def nearest_neighbor_server(input, output, session, shared):
                 # Call run_from_json with virtual path
                 figs, df_data = run_from_json(
                     json_path=params,
-                    save_results=False,  # Return figures directly
+                    save_to_disk=False,  # Return figures directly
                     show_plot=False
                 )
             finally:

--- a/server/ripleyL_server.py
+++ b/server/ripleyL_server.py
@@ -6,7 +6,7 @@ from utils.template_wrapper import (
     register_memory_object,
     unregister_memory_object,
 )
-from spac.templates.visualize_ripley_template import run_from_json
+from spac.templates.visualize_ripley_l_template import run_from_json
 
 
 def ripleyL_server(input, output, session, shared):
@@ -15,7 +15,7 @@ def ripleyL_server(input, output, session, shared):
 
     This implementation registers the in-memory AnnData object with the
     memory registry and delegates plotting to
-    `spac.templates.visualize_ripley_template.run_from_json`.
+    `spac.templates.visualize_ripley_l_template.run_from_json`.
 
     Parameters
     ----------
@@ -81,7 +81,7 @@ def ripleyL_server(input, output, session, shared):
 
             # Call template to get figure and dataframe in-memory
             figs_df: Tuple[Any, Any] = run_from_json(
-                json_path=params, save_results=False, show_plot=False
+                json_path=params, save_to_disk=False, show_plot=False
             )
             if figs_df is None:
                 return None


### PR DESCRIPTION
## Description

This PR updates SPAC Shiny to the official SPAC merge commit containing FNLCR-DMAP/SCSAWorkflow#433's histogram-facet follow-up and updates the existing Ripley L and nearest neighbor callers to the pinned template API.

The change establishes a reproducible SPAC dependency baseline and removes the startup/runtime incompatibilities caused by the pinned package. Later features template adaptation and facet UI exposure will be developed on this PR.

## Related PRs

FNLCR-DMAP/SCSAWorkflow#433

## Changes

- Pins SPAC to official commit `f9886bcde643ebf14e58a31d5ac397e28b6ea510` in both `requirements.txt` and `environment.yml`.
- Updates Ripley L to import `spac.templates.visualize_ripley_l_template`.
- Replaces the removed `save_results=False` argument with `save_to_disk=False` in the Ripley L and nearest neighbor callers.

## Testing

- Rebuilt and restarted the Docker development application.
- Confirmed startup logs no longer report the old Ripley module import error.
- Smoke-tested all tabs including the Histogram, Nearest Neighbor, and Ripley L Shiny paths.

The repository has no focused automated tests for these server template callers, and `pytest` was unavailable in the local environment. Docker startup and the focused Shiny smoke tests were used as the runtime validation.

Initially, pinning spac to the latest commit will cause a module import error. This is fixed by the following commit updating Ripley L module names. 

## Commit Scope

- `bb70f13 chore(deps): pin SPAC to PR #433 merge commit`
- `9d425c8 fix(server): update pinned template callers`